### PR TITLE
feat: add manual pipeline controls to the UI

### DIFF
--- a/src/app/(app)/companies/[id]/page.tsx
+++ b/src/app/(app)/companies/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
 import {
   ArrowLeft,
   Trash2,
@@ -9,9 +10,12 @@ import {
   Lock,
   Clock,
   ExternalLink,
+  Loader2,
+  Play,
 } from "lucide-react";
 import {
   addCompetitor,
+  triggerManualPipelineRun,
   getComparisonSignals,
   getCompanies,
   getCompetitors,
@@ -224,6 +228,7 @@ export default function CompanyDetailPage() {
 
   // Untrack company
   const [untrackOpen, setUntrackOpen] = useState(false);
+  const [manualRunLoading, setManualRunLoading] = useState(false);
 
   // Fetch company
   useEffect(() => {
@@ -368,6 +373,24 @@ export default function CompanyDetailPage() {
     }
   };
 
+  const handleManualRun = async () => {
+    if (!company) return;
+
+    setManualRunLoading(true);
+    try {
+      await triggerManualPipelineRun({ companyIds: [company.company_id] });
+      toast.success(
+        `Queued a manual run for ${company.company_name}. The report email will go to you by default.`,
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to queue manual run",
+      );
+    } finally {
+      setManualRunLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex flex-col gap-6">
@@ -429,6 +452,21 @@ export default function CompanyDetailPage() {
         </div>
 
         <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void handleManualRun()}
+            disabled={manualRunLoading}
+          >
+            {manualRunLoading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+            <span className="ml-1">
+              {manualRunLoading ? "Queueing..." : "Run now"}
+            </span>
+          </Button>
           <AlertDialog open={untrackOpen} onOpenChange={setUntrackOpen}>
             <Button
               size="sm"

--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -2,17 +2,22 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, Play } from "lucide-react";
+import { toast } from "sonner";
 import ShinyText from "@/components/ShinyText";
 import {
   getCompanies,
   addAndTrackCompanySSE,
   searchCatalog,
+  getOrgMembers,
+  triggerManualPipelineRun,
   type TrackedCompany,
   type Company,
+  type OrganizationMember,
 } from "@/lib/api/client";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -26,6 +31,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -38,12 +44,13 @@ const CATALOG_DISPLAY_LIMIT = 15;
 
 export default function CompaniesPage() {
   const router = useRouter();
-  const { currentOrg } = useAuth();
+  const { currentOrg, user } = useAuth();
 
   const [companies, setCompanies] = useState<TrackedCompany[]>([]);
   const [trackingLimit, setTrackingLimit] = useState(5);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCompanyIds, setSelectedCompanyIds] = useState<string[]>([]);
 
   // Add company dialog state
   const [addOpen, setAddOpen] = useState(false);
@@ -58,6 +65,13 @@ export default function CompaniesPage() {
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [catalogFilter, setCatalogFilter] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Manual run dialog state
+  const [runOpen, setRunOpen] = useState(false);
+  const [runLoading, setRunLoading] = useState(false);
+  const [runMembersLoading, setRunMembersLoading] = useState(false);
+  const [orgMembers, setOrgMembers] = useState<OrganizationMember[]>([]);
+  const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>([]);
 
   const fetchCompanies = useCallback(async () => {
     try {
@@ -74,6 +88,14 @@ export default function CompaniesPage() {
     setLoading(true);
     fetchCompanies().finally(() => setLoading(false));
   }, [currentOrg, fetchCompanies]);
+
+  useEffect(() => {
+    setSelectedCompanyIds((prev) =>
+      prev.filter((companyId) =>
+        companies.some((company) => company.company_id === companyId),
+      ),
+    );
+  }, [companies]);
 
   // Load catalog when dialog opens
   useEffect(() => {
@@ -107,6 +129,25 @@ export default function CompaniesPage() {
     }, 300);
     return () => clearTimeout(debounceRef.current);
   }, [catalogFilter, addOpen]);
+
+  useEffect(() => {
+    if (!runOpen || !currentOrg) return;
+
+    setRunMembersLoading(true);
+    getOrgMembers(currentOrg.organization_id)
+      .then((members) => {
+        setOrgMembers(
+          members.filter(
+            (member) =>
+              member.user_id !== null &&
+              member.status !== "pending" &&
+              member.user_id !== user?.id,
+          ),
+        );
+      })
+      .catch(() => setOrgMembers([]))
+      .finally(() => setRunMembersLoading(false));
+  }, [runOpen, currentOrg, user?.id]);
 
   const handleAddByUrl = (e: React.FormEvent) => {
     e.preventDefault();
@@ -207,6 +248,77 @@ export default function CompaniesPage() {
       (c.industry?.toLowerCase().includes(q) ?? false)
     );
   });
+
+  const selectedCompanies = companies.filter((company) =>
+    selectedCompanyIds.includes(company.company_id),
+  );
+
+  const allVisibleSelected =
+    filteredCompanies.length > 0 &&
+    filteredCompanies.every((company) =>
+      selectedCompanyIds.includes(company.company_id),
+    );
+
+  const toggleCompanySelection = (companyId: string, checked: boolean) => {
+    setSelectedCompanyIds((prev) => {
+      if (checked) {
+        return prev.includes(companyId) ? prev : [...prev, companyId];
+      }
+      return prev.filter((id) => id !== companyId);
+    });
+  };
+
+  const toggleVisibleSelection = () => {
+    setSelectedCompanyIds((prev) => {
+      const visibleIds = filteredCompanies.map((company) => company.company_id);
+      if (visibleIds.length === 0) return prev;
+      if (visibleIds.every((companyId) => prev.includes(companyId))) {
+        return prev.filter((companyId) => !visibleIds.includes(companyId));
+      }
+      return [...new Set([...prev, ...visibleIds])];
+    });
+  };
+
+  const toggleRecipientSelection = (userId: string, checked: boolean) => {
+    setSelectedRecipientIds((prev) => {
+      if (checked) {
+        return prev.includes(userId) ? prev : [...prev, userId];
+      }
+      return prev.filter((id) => id !== userId);
+    });
+  };
+
+  const resetRunDialog = () => {
+    setRunOpen(false);
+    setSelectedRecipientIds([]);
+  };
+
+  const handleRunSelected = async () => {
+    if (selectedCompanyIds.length === 0) return;
+
+    setRunLoading(true);
+    try {
+      const result = await triggerManualPipelineRun({
+        companyIds: selectedCompanyIds,
+        recipientUserIds: selectedRecipientIds,
+      });
+
+      const companyCount = result.requested_company_count ?? selectedCompanyIds.length;
+      toast.success(
+        companyCount === 1
+          ? "Manual run queued. The report email will go to you by default."
+          : `Manual run queued for ${companyCount} companies. One combined email will go to you by default.`,
+      );
+      setSelectedCompanyIds([]);
+      resetRunDialog();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to queue manual run",
+      );
+    } finally {
+      setRunLoading(false);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -388,12 +500,140 @@ export default function CompaniesPage() {
         </Dialog>
       </div>
 
-      <Input
-        placeholder="Search tracked companies..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        className="max-w-sm"
-      />
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <Input
+          placeholder="Search tracked companies..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="max-w-sm"
+        />
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={filteredCompanies.length === 0}
+            onClick={toggleVisibleSelection}
+          >
+            {allVisibleSelected ? "Clear visible selection" : "Select visible"}
+          </Button>
+
+          <Dialog
+            open={runOpen}
+            onOpenChange={(open) => {
+              if (!runLoading) {
+                if (!open) {
+                  setSelectedRecipientIds([]);
+                }
+                setRunOpen(open);
+              }
+            }}
+          >
+            <DialogTrigger
+              render={<Button size="sm" disabled={selectedCompanyIds.length === 0} />}
+            >
+              <Play className="h-4 w-4" />
+              Run Selected
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-lg">
+              <DialogHeader>
+                <DialogTitle>Run Selected Companies</DialogTitle>
+                <DialogDescription>
+                  This queues one explicit manual request for the selected companies.
+                  You&apos;ll get one combined report email by default.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Selected companies</Label>
+                  <div className="max-h-40 space-y-2 overflow-y-auto rounded-lg border p-3">
+                    {selectedCompanies.map((company) => (
+                      <div
+                        key={company.company_id}
+                        className="flex items-center justify-between gap-3 text-sm"
+                      >
+                        <span className="font-medium">{company.company_name}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {company.domain}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Default delivery</Label>
+                  <p className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+                    This run will send the digest to{" "}
+                    <span className="font-medium text-foreground">
+                      {user?.email ?? "you"}
+                    </span>{" "}
+                    by default.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Also send to teammates</Label>
+                  <div className="rounded-lg border p-3">
+                    {runMembersLoading ? (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Loading organization members...
+                      </div>
+                    ) : orgMembers.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        No additional organization members are available yet.
+                      </p>
+                    ) : (
+                      <div className="space-y-3">
+                        {orgMembers.map((member) => (
+                          <label
+                            key={member.id}
+                            className="flex items-start gap-3 rounded-md"
+                          >
+                            <Checkbox
+                              checked={selectedRecipientIds.includes(member.user_id!)}
+                              onCheckedChange={(checked) =>
+                                toggleRecipientSelection(
+                                  member.user_id!,
+                                  checked === true,
+                                )
+                              }
+                            />
+                            <div className="flex flex-col">
+                              <span className="text-sm font-medium">
+                                {member.email ?? member.user_id}
+                              </span>
+                              <span className="text-xs capitalize text-muted-foreground">
+                                {member.role}
+                              </span>
+                            </div>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={resetRunDialog}
+                  disabled={runLoading}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleRunSelected} disabled={runLoading}>
+                  {runLoading ? "Queueing..." : "Queue manual run"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
 
       {loading ? (
         <div className="flex flex-col gap-2">
@@ -413,6 +653,7 @@ export default function CompaniesPage() {
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-12">Select</TableHead>
                 <TableHead>Company</TableHead>
                 <TableHead>Domain</TableHead>
                 <TableHead>Industry</TableHead>
@@ -435,6 +676,15 @@ export default function CompaniesPage() {
                   tabIndex={0}
                   role="link"
                 >
+                  <TableCell onClick={(e) => e.stopPropagation()}>
+                    <Checkbox
+                      checked={selectedCompanyIds.includes(company.company_id)}
+                      onCheckedChange={(checked) =>
+                        toggleCompanySelection(company.company_id, checked === true)
+                      }
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </TableCell>
                   <TableCell className="font-medium">
                     <span className="flex items-center gap-2">
                       {company.company_name}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -96,6 +96,12 @@ export interface UserSettings {
   email_frequency: EmailFrequency;
 }
 
+export interface TriggerPipelineResponse {
+  status: "queued";
+  source: "manual";
+  requested_company_count: number | null;
+}
+
 // ---------------------------------------------------------------------------
 // Organizations
 // ---------------------------------------------------------------------------
@@ -205,6 +211,36 @@ export async function getCompanies(): Promise<{ companies: TrackedCompany[]; tra
 
 export async function untrackCompany(id: string): Promise<void> {
   await authFetch(`${API_BASE}/companies/${id}`, { method: "DELETE" });
+}
+
+export async function triggerManualPipelineRun(input: {
+  companyIds: string[];
+  recipientUserIds?: string[];
+}): Promise<TriggerPipelineResponse> {
+  const companyIds = input.companyIds.filter(Boolean);
+  if (companyIds.length === 0) {
+    throw new Error("Select at least one company to run");
+  }
+
+  const payload: {
+    company_id?: string;
+    company_ids?: string[];
+    recipient_user_ids?: string[];
+  } = companyIds.length === 1
+    ? { company_id: companyIds[0] }
+    : { company_ids: companyIds };
+
+  if (input.recipientUserIds?.length) {
+    payload.recipient_user_ids = input.recipientUserIds;
+  }
+
+  const res = await authFetch(`${API_BASE}/trigger-pipeline`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  await requireOk(res, "Failed to queue manual pipeline run");
+  return res.json();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add batch manual run controls to the tracked companies page
- add a single-company Run now action to the company detail page
- keep manual delivery requester-scoped by default with optional same-org teammates

## Verification
- npx tsc --noEmit
- npm run build
- TinyFish verified the batch Run Selected flow
- TinyFish verified the single-company Run now flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Run now" button to manually trigger pipeline runs from company detail pages
  * Enabled multi-company selection with batch manual run queuing
  * Added optional team member selection for report email recipients
  * Integrated user feedback notifications for manual run requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->