### PR TITLE
Rebuild request email pipeline flow

### DIFF
--- a/src/app/(app)/companies/[id]/page.tsx
+++ b/src/app/(app)/companies/[id]/page.tsx
@@ -356,8 +356,10 @@ export default function CompanyDetailPage() {
           ? `${result.competitor.company_name} was added. Fresh signals are being prepared now.`
           : `${result.competitor.company_name} was added to the competitor timeline.`,
       );
-    } catch {
-      setCompetitorMessage("Failed to add competitor.");
+    } catch (error) {
+      setCompetitorMessage(
+        error instanceof Error ? error.message : "Failed to add competitor.",
+      );
     } finally {
       setCompetitorSaving(false);
     }

--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -303,7 +303,8 @@ export default function CompaniesPage() {
         recipientUserIds: selectedRecipientIds,
       });
 
-      const companyCount = result.requested_company_count ?? selectedCompanyIds.length;
+      const companyCount =
+        result.requestedCompanyCount ?? selectedCompanyIds.length;
       toast.success(
         companyCount === 1
           ? "Manual run queued. The report email will go to you by default."
@@ -409,8 +410,10 @@ export default function CompaniesPage() {
                           className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5 hover:bg-muted/50 transition-colors"
                         >
                           <div className="flex flex-col min-w-0 flex-1">
-                            <span className="text-sm font-medium truncate leading-snug">{c.company_name}</span>
-                            <span className="text-xs text-muted-foreground truncate mt-0.5">
+                            <span className="break-words text-sm font-medium leading-snug sm:truncate">
+                              {c.company_name}
+                            </span>
+                            <span className="mt-0.5 break-all text-xs text-muted-foreground sm:truncate">
                               {c.domain}
                               {c.industry ? ` · ${c.industry}` : ""}
                             </span>
@@ -421,7 +424,7 @@ export default function CompaniesPage() {
                             <Button
                               size="sm"
                               variant="outline"
-                              className="shrink-0"
+                              className="min-h-9 shrink-0 px-3"
                               disabled={addStoring}
                               onClick={() => handleTrackFromCatalog(c.website_url)}
                             >
@@ -508,10 +511,11 @@ export default function CompaniesPage() {
           className="max-w-sm"
         />
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
           <Button
             size="sm"
             variant="outline"
+            className="w-full sm:w-auto"
             disabled={filteredCompanies.length === 0}
             onClick={toggleVisibleSelection}
           >
@@ -530,7 +534,13 @@ export default function CompaniesPage() {
             }}
           >
             <DialogTrigger
-              render={<Button size="sm" disabled={selectedCompanyIds.length === 0} />}
+              render={(
+                <Button
+                  size="sm"
+                  className="w-full min-w-[9rem] sm:w-auto"
+                  disabled={selectedCompanyIds.length === 0}
+                />
+              )}
             >
               <Play className="h-4 w-4" />
               Run Selected
@@ -649,15 +659,85 @@ export default function CompaniesPage() {
           </p>
         </div>
       ) : (
-        <div className="rounded-xl border">
-          <Table>
+        <>
+          <div className="grid gap-3 md:hidden">
+            {filteredCompanies.map((company) => (
+              <div
+                key={company.company_id}
+                className="rounded-xl border bg-card p-4 shadow-sm"
+              >
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    checked={selectedCompanyIds.includes(company.company_id)}
+                    onCheckedChange={(checked) =>
+                      toggleCompanySelection(company.company_id, checked === true)
+                    }
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={`Select ${company.company_name}`}
+                    className="mt-1"
+                  />
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 flex-col items-start gap-3 text-left"
+                    onClick={() => router.push(`/companies/${company.company_id}`)}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="break-words text-sm font-semibold leading-snug">
+                          {company.company_name}
+                        </span>
+                        {company.platform_status === "enriching" && (
+                          <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                        )}
+                      </div>
+                      <p className="mt-1 break-all text-xs text-muted-foreground">
+                        {company.domain}
+                      </p>
+                    </div>
+
+                    <div className="grid w-full gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                      <div className="rounded-lg bg-muted/40 px-3 py-2">
+                        <span className="block text-[11px] uppercase tracking-wide text-muted-foreground/80">
+                          Industry
+                        </span>
+                        <span className="mt-1 block">
+                          {company.platform_status === "enriching" && !company.industry ? (
+                            <ShinyText text="Enriching..." className="text-xs" />
+                          ) : (
+                            company.industry ?? "—"
+                          )}
+                        </span>
+                      </div>
+                      <div className="rounded-lg bg-muted/40 px-3 py-2">
+                        <span className="block text-[11px] uppercase tracking-wide text-muted-foreground/80">
+                          Last Updated
+                        </span>
+                        <span className="mt-1 block">
+                          {company.platform_status === "enriching" && !company.last_agent_run ? (
+                            <ShinyText text="Enriching..." className="text-xs" />
+                          ) : company.last_agent_run ? (
+                            new Date(company.last_agent_run).toLocaleDateString()
+                          ) : (
+                            "—"
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="hidden overflow-x-auto rounded-xl border md:block">
+            <Table className="w-full table-fixed md:table-auto">
             <TableHeader>
               <TableRow>
                 <TableHead className="w-12">Select</TableHead>
                 <TableHead>Company</TableHead>
-                <TableHead>Domain</TableHead>
-                <TableHead>Industry</TableHead>
-                <TableHead>Last Updated</TableHead>
+                <TableHead className="w-[10rem] sm:w-auto">Domain</TableHead>
+                <TableHead className="hidden md:table-cell">Industry</TableHead>
+                <TableHead className="hidden md:table-cell">Last Updated</TableHead>
 
               </TableRow>
             </TableHeader>
@@ -686,22 +766,22 @@ export default function CompaniesPage() {
                     />
                   </TableCell>
                   <TableCell className="font-medium">
-                    <span className="flex items-center gap-2">
+                    <span className="flex min-w-0 items-center gap-2 break-words">
                       {company.company_name}
                       {company.platform_status === "enriching" && (
                         <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                       )}
                     </span>
                   </TableCell>
-                  <TableCell className="text-muted-foreground">
+                  <TableCell className="max-w-[10rem] break-all whitespace-normal text-muted-foreground">
                     {company.domain}
                   </TableCell>
-                  <TableCell className="text-muted-foreground">
+                  <TableCell className="hidden text-muted-foreground md:table-cell">
                     {company.platform_status === "enriching" && !company.industry
                       ? <ShinyText text="Enriching..." className="text-sm" />
                       : company.industry ?? "—"}
                   </TableCell>
-                  <TableCell className="text-muted-foreground">
+                  <TableCell className="hidden text-muted-foreground md:table-cell">
                     {company.platform_status === "enriching" && !company.last_agent_run
                       ? <ShinyText text="Enriching..." className="text-sm" />
                       : company.last_agent_run
@@ -711,8 +791,9 @@ export default function CompaniesPage() {
                 </TableRow>
               ))}
             </TableBody>
-          </Table>
-        </div>
+            </Table>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -23,6 +23,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
+  SidebarTrigger,
 } from "@/components/ui/sidebar";
 import {
   DropdownMenu,
@@ -58,7 +59,14 @@ function AppSidebar() {
     <Sidebar collapsible="icon">
       <SidebarHeader className="border-b border-sidebar-border group-data-[collapsible=icon]:border-none">
         <div className="flex h-8 items-center gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
-          <Image src="/logo.png" alt="Daily Delta" width={20} height={20} className="h-5 w-5 shrink-0" />
+          <Image
+            src="/logo.png"
+            alt="Daily Delta"
+            width={20}
+            height={20}
+            className="h-5 w-5 shrink-0"
+            unoptimized
+          />
           <span className="text-lg text-muted-foreground group-data-[collapsible=icon]:hidden">/</span>
           <span className="text-sm font-semibold leading-none truncate group-data-[collapsible=icon]:hidden">
             {currentOrg?.name ?? "Daily Delta"}
@@ -132,7 +140,7 @@ function AppSidebar() {
 }
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const { user, loading } = useAuth();
+  const { user, loading, currentOrg } = useAuth();
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -163,6 +171,20 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <AppSidebar />
       </div>
       <SidebarInset>
+        <header className="sticky top-0 z-20 flex items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur md:hidden">
+          <SidebarTrigger
+            aria-label="Open navigation"
+            title="Open navigation"
+            size="icon-lg"
+            className="shrink-0"
+          />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">
+              {currentOrg?.name ?? "Daily Delta"}
+            </p>
+            <p className="text-xs text-muted-foreground">Navigation</p>
+          </div>
+        </header>
         <main className="flex-1 p-4">{children}</main>
       </SidebarInset>
     </SidebarProvider>

--- a/src/app/api/companies/[id]/competitors/route.ts
+++ b/src/app/api/companies/[id]/competitors/route.ts
@@ -131,13 +131,25 @@ export const POST = withOrg(async (req: NextRequest, ctx: OrgAuthContext) => {
     );
   }
 
-  await trackCompany(ctx.organizationId, competitor.company_id, ctx.userId);
-  await addCompetitor(
-    ctx.organizationId,
-    companyId,
-    competitor.company_id,
-    ctx.userId,
-  );
+  try {
+    await trackCompany(ctx.organizationId, competitor.company_id, ctx.userId);
+    await addCompetitor(
+      ctx.organizationId,
+      companyId,
+      competitor.company_id,
+      ctx.userId,
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to add competitor";
+
+    return Response.json(
+      { error: message },
+      {
+        status: message.startsWith("Tracking limit reached") ? 400 : 500,
+      },
+    );
+  }
 
   const refreshQueued =
     shouldRunDiscovery || needsRefresh(competitor.last_agent_run);

--- a/src/app/api/pipeline-requests/[id]/route.ts
+++ b/src/app/api/pipeline-requests/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { withOrg, type OrgAuthContext } from "@/app/api/_lib/with-auth";
+import {
+  getPipelineRequestSnapshot,
+  previewPipelineRequestDigest,
+} from "@/services/pipeline-request-service";
+
+function extractRequestId(req: NextRequest): string {
+  const segments = req.nextUrl.pathname.split("/");
+  return segments[segments.indexOf("pipeline-requests") + 1];
+}
+
+export const GET = withOrg(async (req: NextRequest, ctx: OrgAuthContext) => {
+  try {
+    const requestId = extractRequestId(req);
+    const snapshot = await getPipelineRequestSnapshot(
+      requestId,
+      ctx.organizationId,
+    );
+
+    if (!snapshot) {
+      return Response.json(
+        { error: "Pipeline request not found" },
+        { status: 404 },
+      );
+    }
+
+    const preview = req.nextUrl.searchParams.get("preview");
+    if (preview === "true") {
+      if (!snapshot.allCompaniesTerminal) {
+        return Response.json(
+          { error: "Pipeline request is not ready for preview" },
+          { status: 409 },
+        );
+      }
+
+      const digestPreview = await previewPipelineRequestDigest(
+        requestId,
+        ctx.organizationId,
+      );
+      if (!digestPreview) {
+        return Response.json(
+          { error: "Pipeline request preview not found" },
+          { status: 404 },
+        );
+      }
+
+      return new Response(digestPreview.html, {
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "X-Digest-Subject": encodeURIComponent(digestPreview.subject),
+        },
+      });
+    }
+
+    return Response.json(snapshot);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    return Response.json({ error: message }, { status: 500 });
+  }
+});

--- a/src/app/api/trigger-pipeline/route.ts
+++ b/src/app/api/trigger-pipeline/route.ts
@@ -20,6 +20,7 @@ export async function POST(request: NextRequest) {
     company_id?: string;
     company_ids?: string[];
     recipient_user_ids?: string[];
+    request_key?: string;
   } = {};
   try {
     body = await request.json();
@@ -32,16 +33,19 @@ export async function POST(request: NextRequest) {
 
   try {
     if (isCronRequest) {
-      await enqueuePipelineRequestedEvent({
-        source: "manual",
+      const queued = await enqueuePipelineRequestedEvent({
+        source: "cron",
+        requestKey: body.request_key,
         companyIds: ids,
       });
 
       return NextResponse.json(
         {
           status: "queued",
-          source: "manual",
-          requested_company_count: ids?.length ?? null,
+          source: "cron",
+          requestId: queued.requestId,
+          requestKey: queued.requestKey,
+          requestedCompanyCount: ids?.length ?? null,
         },
         { status: 202 },
       );
@@ -76,8 +80,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    await enqueuePipelineRequestedEvent({
+    const queued = await enqueuePipelineRequestedEvent({
       source: "manual",
+      requestKey: body.request_key,
       companyIds: ids,
       organizationId,
       requestedByUserId: user.userId,
@@ -88,7 +93,9 @@ export async function POST(request: NextRequest) {
       {
         status: "queued",
         source: "manual",
-        requested_company_count: ids?.length ?? null,
+        requestId: queued.requestId,
+        requestKey: queued.requestKey,
+        requestedCompanyCount: ids?.length ?? null,
       },
       { status: 202 },
     );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -74,6 +74,7 @@ function LoginForm() {
             width={48}
             height={48}
             className="size-12"
+            unoptimized
           />
         </div>
         <Card>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -78,6 +78,7 @@ function SignUpForm() {
             width={48}
             height={48}
             className="size-12"
+            unoptimized
           />
         </div>
         <Card>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -264,6 +264,8 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
+      aria-label="Toggle sidebar"
+      title="Toggle sidebar"
       className={cn(className)}
       onClick={(event) => {
         onClick?.(event)

--- a/src/inngest/events.ts
+++ b/src/inngest/events.ts
@@ -7,6 +7,8 @@ export type PipelineRequestSource = "cron" | "manual" | "refresh";
 
 export interface PipelineRequestedEventData {
   source: PipelineRequestSource;
+  requestId?: string;
+  requestKey?: string;
   companyIds?: string[];
   organizationId?: string;
   requestedByUserId?: string;

--- a/src/inngest/functions/daily-pipeline.ts
+++ b/src/inngest/functions/daily-pipeline.ts
@@ -2,6 +2,17 @@ import { cron } from "inngest";
 import { PIPELINE_REQUESTED_EVENT } from "@/inngest/events";
 import { inngest } from "../client";
 
+function buildDailyRequestKey(date: Date): string {
+  const day = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+
+  return `cron:${day}`;
+}
+
 export const dailyPipeline = inngest.createFunction(
   {
     id: "daily-pipeline",
@@ -12,6 +23,7 @@ export const dailyPipeline = inngest.createFunction(
       name: PIPELINE_REQUESTED_EVENT,
       data: {
         source: "cron",
+        requestKey: buildDailyRequestKey(new Date()),
       },
     });
 

--- a/src/inngest/functions/pipeline-workflow.ts
+++ b/src/inngest/functions/pipeline-workflow.ts
@@ -16,9 +16,17 @@ import {
   markCompanyRunsRequested,
   markPipelineRequestFinalized,
   preparePipelineRequest,
-  processQueuedCompanyRun,
   sendPipelineDigestDelivery,
 } from "@/services/pipeline-request-service";
+import {
+  failCompanyRun,
+  finalizeCompanyAgents,
+  pollCompanyAgents,
+  submitCompanyAgents,
+} from "@/services/pipeline-service";
+
+const AGENT_POLL_INTERVAL = "1 min";
+const MAX_AGENT_POLLS = 480;
 
 function sanitizeStepId(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 48);
@@ -33,7 +41,7 @@ export const pipelineRequested = inngest.createFunction(
     const data = event.data as PipelineRequestedEventData;
 
     const prepared = await step.run("prepare-pipeline-request", () =>
-      preparePipelineRequest(event.id, data.source, data.companyIds, {
+      preparePipelineRequest(event.id, data.source, data.requestId, data.requestKey, data.companyIds, {
         organizationId: data.organizationId,
         requestedByUserId: data.requestedByUserId,
         recipientUserIds: data.recipientUserIds,
@@ -79,18 +87,58 @@ export const processCompanyPipelineRun = inngest.createFunction(
   },
   async ({ event, step }) => {
     const data = event.data as CompanyRequestedEventData;
-    const result = await step.run("process-company-run", () =>
-      processQueuedCompanyRun(data.companyRunId),
-    );
+    try {
+      await step.run("submit-company-agents", () =>
+        submitCompanyAgents(data.companyRunId),
+      );
 
-    await step.sendEvent("notify-company-run-completed", {
-      name: COMPANY_COMPLETED_EVENT,
-      data: {
-        companyRunId: data.companyRunId,
-      },
-    });
+      let pollResult = await step.run("poll-company-agents-0", () =>
+        pollCompanyAgents(data.companyRunId),
+      );
 
-    return result;
+      let pollAttempt = 0;
+      while (!pollResult.terminal) {
+        pollAttempt += 1;
+        if (pollAttempt > MAX_AGENT_POLLS) {
+          throw new Error(
+            `Company run ${data.companyRunId} exceeded the maximum poll budget`,
+          );
+        }
+
+        await step.sleep(`wait-for-company-agents-${pollAttempt}`, AGENT_POLL_INTERVAL);
+        pollResult = await step.run(`poll-company-agents-${pollAttempt}`, () =>
+          pollCompanyAgents(data.companyRunId),
+        );
+      }
+
+      const result = await step.run("finalize-company-agents", () =>
+        finalizeCompanyAgents(data.companyRunId),
+      );
+
+      await step.sendEvent("notify-company-run-completed", {
+        name: COMPANY_COMPLETED_EVENT,
+        data: {
+          companyRunId: data.companyRunId,
+        },
+      });
+
+      return result;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      const failed = await step.run("mark-company-run-failed", () =>
+        failCompanyRun(data.companyRunId, message),
+      );
+
+      await step.sendEvent("notify-company-run-completed-after-failure", {
+        name: COMPANY_COMPLETED_EVENT,
+        data: {
+          companyRunId: data.companyRunId,
+        },
+      });
+
+      return failed;
+    }
   },
 );
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -99,7 +99,53 @@ export interface UserSettings {
 export interface TriggerPipelineResponse {
   status: "queued";
   source: "manual";
-  requested_company_count: number | null;
+  requestId: string | null;
+  requestKey: string | null;
+  requestedCompanyCount: number | null;
+}
+
+export interface PipelineRequestCompanySummary {
+  companyId: string;
+  companyName: string;
+  status: "queued" | "running" | "waiting_for_rerun" | "completed" | "failed";
+  signalCount: number;
+  reportId: string | null;
+  error: string | null;
+}
+
+export interface PipelineRequestDeliverySummary {
+  orgId: string;
+  email: string;
+  sentAt: string | null;
+}
+
+export interface PipelineRequestSnapshot {
+  requestId: string;
+  requestKey: string | null;
+  source: "manual" | "cron" | "refresh";
+  status: "queued" | "running" | "finalizing" | "completed" | "completed_with_errors";
+  requestedCompanyCount: number;
+  organizationId: string | null;
+  requestedByUserId: string | null;
+  recipientUserIds: string[] | null;
+  allCompaniesTerminal: boolean;
+  previewAvailable: boolean;
+  hadCompanyFailures: boolean;
+  companies: PipelineRequestCompanySummary[];
+  deliveries: PipelineRequestDeliverySummary[];
+}
+
+export interface PipelineRequestPreview {
+  subject: string;
+  html: string;
+}
+
+function generateRequestKey(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `manual-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -216,6 +262,7 @@ export async function untrackCompany(id: string): Promise<void> {
 export async function triggerManualPipelineRun(input: {
   companyIds: string[];
   recipientUserIds?: string[];
+  requestKey?: string;
 }): Promise<TriggerPipelineResponse> {
   const companyIds = input.companyIds.filter(Boolean);
   if (companyIds.length === 0) {
@@ -226,9 +273,12 @@ export async function triggerManualPipelineRun(input: {
     company_id?: string;
     company_ids?: string[];
     recipient_user_ids?: string[];
+    request_key?: string;
   } = companyIds.length === 1
     ? { company_id: companyIds[0] }
     : { company_ids: companyIds };
+
+  payload.request_key = input.requestKey ?? generateRequestKey();
 
   if (input.recipientUserIds?.length) {
     payload.recipient_user_ids = input.recipientUserIds;
@@ -263,6 +313,27 @@ export async function previewReportEmail(reportId: string): Promise<string> {
   return res.text();
 }
 
+export async function getPipelineRequest(
+  requestId: string,
+): Promise<PipelineRequestSnapshot> {
+  const res = await authFetch(`${API_BASE}/pipeline-requests/${requestId}`);
+  await requireOk(res, "Failed to fetch pipeline request");
+  return res.json();
+}
+
+export async function previewPipelineRequestEmail(
+  requestId: string,
+): Promise<PipelineRequestPreview> {
+  const res = await authFetch(`${API_BASE}/pipeline-requests/${requestId}?preview=true`);
+  await requireOk(res, "Failed to preview pipeline request email");
+  const encodedSubject = res.headers.get("x-digest-subject") ?? "";
+
+  return {
+    subject: encodedSubject ? decodeURIComponent(encodedSubject) : "",
+    html: await res.text(),
+  };
+}
+
 export async function getReports(companyId?: string): Promise<Report[]> {
   const url = companyId
     ? `${API_BASE}/reports?company_id=${companyId}`
@@ -295,6 +366,7 @@ export async function getComparisonSignals(
   params.set("company_ids", companyIds.join(","));
   params.set("limit", String(limit));
   const res = await authFetch(`${API_BASE}/signals?${params}`);
+  await requireOk(res, "Failed to load comparison signals");
   return res.json();
 }
 
@@ -302,6 +374,7 @@ export async function getCompetitors(
   companyId: string,
 ): Promise<{ competitors: CompetitorLink[]; suggestions: Company[] }> {
   const res = await authFetch(`${API_BASE}/companies/${companyId}/competitors`);
+  await requireOk(res, "Failed to load competitors");
   return res.json();
 }
 
@@ -316,6 +389,7 @@ export async function addCompetitor(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
+  await requireOk(res, "Failed to add competitor");
   return res.json();
 }
 
@@ -323,7 +397,7 @@ export async function removeCompetitor(
   companyId: string,
   competitorCompanyId: string,
 ): Promise<void> {
-  await authFetch(
+  const res = await authFetch(
     `${API_BASE}/companies/${companyId}/competitors?competitor_company_id=${encodeURIComponent(
       competitorCompanyId,
     )}`,
@@ -331,6 +405,7 @@ export async function removeCompetitor(
       method: "DELETE",
     },
   );
+  await requireOk(res, "Failed to remove competitor");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,9 +270,14 @@ export interface CompanyPipelineResult {
   findings: SignalFinding[];
 }
 
+export type DigestCompanyStatus = 'changed' | 'no_change' | 'failed';
+
 export interface DigestCompany {
   company: Company;
   findings: SignalFinding[];
+  status: DigestCompanyStatus;
+  reportId?: string;
+  error?: string;
 }
 
 export interface CompetitorLink {

--- a/src/services/company-service.ts
+++ b/src/services/company-service.ts
@@ -136,6 +136,20 @@ export async function trackCompany(
 ): Promise<void> {
   const supabase = createAdminClient();
 
+  const { count: existingCount, error: existingError } = await supabase
+    .from("organization_tracked_companies")
+    .select("id", { count: "exact", head: true })
+    .eq("organization_id", organizationId)
+    .eq("company_id", companyId);
+
+  if (existingError) {
+    throw new Error(`Failed to check tracked company: ${existingError.message}`);
+  }
+
+  if ((existingCount ?? 0) > 0) {
+    return;
+  }
+
   // Check tracking limit
   const { data: org } = await supabase
     .from("organizations")

--- a/src/services/email-service.ts
+++ b/src/services/email-service.ts
@@ -1,7 +1,14 @@
 import { Resend } from "resend";
-import { generateText } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
 import { ReportData, Company, SignalFinding, DigestCompany } from "@/lib/types";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 function csvEscape(value: string): string {
   let safe = value;
@@ -418,41 +425,64 @@ function getSignalTypeLabel(type: string): string {
 async function generateDigestTldr(
   digestCompanies: DigestCompany[],
 ): Promise<string> {
-  try {
-    const totalSignals = digestCompanies.reduce(
-      (sum, dc) => sum + dc.findings.length,
-      0,
-    );
+  const changedCompanies = digestCompanies
+    .filter((company) => company.status === "changed" && company.findings.length > 0)
+    .sort((a, b) => b.findings.length - a.findings.length);
 
-    // Give the LLM the actual signal titles/summaries, not just counts
-    const companyBriefs = digestCompanies.map((dc) => {
-      const findingLines = dc.findings
-        .slice(0, 15) // cap per company to keep prompt reasonable
-        .map((f) => `  - [${getSignalTypeLabel(f.signal_type)}] ${f.title}: ${f.summary}`)
-        .join("\n");
-      return `${dc.company.company_name} (${dc.company.domain}):\n${findingLines}`;
-    });
-
-    const { text } = await generateText({
-      model: anthropic("claude-sonnet-4-20250514"),
-      system: `You write TLDR summaries for a VC-focused competitive intelligence digest.
-
-Your job: surface the 3-5 most important, actionable findings across all companies. Think like a VC — what matters is funding rounds, product launches, leadership changes, revenue milestones, and competitive moves.
-
-Rules:
-- Plain text only, no markdown, no bullet points, no bold
-- 3-4 sentences max
-- Name specific companies and what happened — no vague "heightened activity" language
-- End with a short note like "X more signals across Y companies below."
-- Be direct and specific. Every sentence should contain a concrete fact.`,
-      prompt: `Here are today's signals across ${digestCompanies.length} companies (${totalSignals} total signals). Write the TLDR:\n\n${companyBriefs.join("\n\n")}`,
-    });
-
-    return text.trim();
-  } catch (err) {
-    console.error("[Email] Failed to generate TLDR:", err);
+  const totalSignals = changedCompanies.reduce(
+    (sum, dc) => sum + dc.findings.length,
+    0,
+  );
+  if (changedCompanies.length === 0 || totalSignals === 0) {
     return "";
   }
+
+  const noChangeCount = digestCompanies.filter(
+    (company) => company.status === "no_change",
+  ).length;
+  const failedCount = digestCompanies.filter(
+    (company) => company.status === "failed",
+  ).length;
+  const highlightedCompanies = changedCompanies.slice(0, 3);
+  const highlightedSummary = highlightedCompanies
+    .map((company) => {
+      const primaryFinding = company.findings[0];
+      const signalType = primaryFinding
+        ? getSignalTypeLabel(primaryFinding.signal_type).toLowerCase()
+        : "signals";
+
+      return `${company.company.company_name} (${company.findings.length} new ${company.findings.length === 1 ? "signal" : "signals"}, led by ${signalType})`;
+    })
+    .join(", ");
+
+  const remainingCompanies = changedCompanies.length - highlightedCompanies.length;
+  const summaryParts = [
+    `${highlightedSummary} stood out in this run.`,
+    `We detected ${totalSignals} new signals across ${changedCompanies.length} compan${changedCompanies.length === 1 ? "y" : "ies"}.`,
+  ];
+
+  if (remainingCompanies > 0) {
+    summaryParts.push(
+      `${remainingCompanies} additional compan${remainingCompanies === 1 ? "y" : "ies"} with changes appear in the detailed sections below.`,
+    );
+  }
+
+  if (noChangeCount > 0 || failedCount > 0) {
+    const outcomeNotes = [];
+    if (noChangeCount > 0) {
+      outcomeNotes.push(
+        `${noChangeCount} compan${noChangeCount === 1 ? "y had" : "ies had"} no new signals`,
+      );
+    }
+    if (failedCount > 0) {
+      outcomeNotes.push(
+        `${failedCount} compan${failedCount === 1 ? "y" : "ies"} failed to process`,
+      );
+    }
+    summaryParts.push(`${outcomeNotes.join(", ")}.`);
+  }
+
+  return summaryParts.join(" ");
 }
 
 function buildDigestEmail(digestCompanies: DigestCompany[], tldr?: string): string {
@@ -472,10 +502,60 @@ function buildDigestEmail(digestCompanies: DigestCompany[], tldr?: string): stri
   });
 
   const totalSignals = digestCompanies.reduce((sum, dc) => sum + dc.findings.length, 0);
+  const changedCount = digestCompanies.filter((dc) => dc.status === "changed").length;
+  const noChangeCount = digestCompanies.filter((dc) => dc.status === "no_change").length;
+  const failedCount = digestCompanies.filter((dc) => dc.status === "failed").length;
 
   // Build company sections
   const companySectionsHtml = digestCompanies.map((dc, companyIdx) => {
-    const { company, findings } = dc;
+    const { company, findings, status, error } = dc;
+
+    const metaLabel =
+      status === "failed"
+        ? "Pipeline failed"
+        : status === "no_change"
+          ? "No new signals"
+          : `${findings.length} new signal${findings.length !== 1 ? "s" : ""}`;
+
+    if (status === "failed") {
+      return `
+      <tr>
+        <td style="padding:${companyIdx === 0 ? "0" : "32px"} 40px 0;">
+          ${companyIdx > 0 ? `<div style="border-top:3px solid #1a1a1a;margin-bottom:32px;"></div>` : ""}
+          <h2 style="margin:0 0 4px;font-family:${serif};font-size:22px;font-weight:700;color:#1a1a1a;letter-spacing:-0.3px;">
+            ${company.company_name}
+          </h2>
+          <p style="margin:0 0 20px;font-family:${serif};font-size:13px;color:#666;">
+            ${company.domain}${company.industry ? ` · ${company.industry}` : ""} · ${metaLabel}
+          </p>
+          <div style="padding:16px 18px;border:1px solid #f0d0d0;background:#fff7f7;">
+            <p style="margin:0;font-family:${serif};font-size:14px;line-height:1.6;color:#7a1f1f;">
+              <strong>Pipeline Failed:</strong> ${escapeHtml(error || "An unknown error occurred while generating this company summary.")}
+            </p>
+          </div>
+        </td>
+      </tr>`;
+    }
+
+    if (status === "no_change") {
+      return `
+      <tr>
+        <td style="padding:${companyIdx === 0 ? "0" : "32px"} 40px 0;">
+          ${companyIdx > 0 ? `<div style="border-top:3px solid #1a1a1a;margin-bottom:32px;"></div>` : ""}
+          <h2 style="margin:0 0 4px;font-family:${serif};font-size:22px;font-weight:700;color:#1a1a1a;letter-spacing:-0.3px;">
+            ${company.company_name}
+          </h2>
+          <p style="margin:0 0 20px;font-family:${serif};font-size:13px;color:#666;">
+            ${company.domain}${company.industry ? ` · ${company.industry}` : ""} · ${metaLabel}
+          </p>
+          <div style="padding:16px 18px;border:1px solid #e6e6e6;background:#fafafa;">
+            <p style="margin:0;font-family:${serif};font-size:14px;line-height:1.6;color:#555;">
+              No new signals were detected for this company in this request.
+            </p>
+          </div>
+        </td>
+      </tr>`;
+    }
 
     // Group findings by signal_type
     const byType = new Map<string, SignalFinding[]>();
@@ -535,7 +615,7 @@ function buildDigestEmail(digestCompanies: DigestCompany[], tldr?: string): stri
             ${company.company_name}
           </h2>
           <p style="margin:0 0 20px;font-family:${serif};font-size:13px;color:#666;">
-            ${company.domain}${company.industry ? ` · ${company.industry}` : ""} · ${findings.length} new signal${findings.length !== 1 ? "s" : ""}
+            ${company.domain}${company.industry ? ` · ${company.industry}` : ""} · ${metaLabel}
           </p>
           ${typeSectionsHtml}
         </td>
@@ -563,6 +643,9 @@ function buildDigestEmail(digestCompanies: DigestCompany[], tldr?: string): stri
                   </p>
                   <p style="margin:8px 0 0;font-family:${serif};font-size:14px;color:#666;line-height:1.5;">
                     ${digestCompanies.map((dc) => dc.company.company_name).join(", ")}
+                  </p>
+                  <p style="margin:8px 0 0;font-family:${mono};font-size:11px;letter-spacing:0.6px;color:#777;text-transform:uppercase;">
+                    ${changedCount} changed · ${noChangeCount} unchanged · ${failedCount} failed · ${totalSignals} total signals
                   </p>
                 </td>
               </tr>
@@ -615,19 +698,55 @@ function buildDigestEmail(digestCompanies: DigestCompany[], tldr?: string): stri
 
 function buildDigestCSV(digestCompanies: DigestCompany[]): string {
   const rows: string[] = [];
-  rows.push("Company,Section,Title,Summary,Source,URL,Detected At");
+  rows.push("Company,Status,Section,Title,Summary,Source,URL,Detected At,Error");
 
-  for (const { company, findings } of digestCompanies) {
+  for (const { company, findings, status, error } of digestCompanies) {
+    if (status === "failed") {
+      rows.push(
+        [
+          csvEscape(company.company_name),
+          csvEscape(status),
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          csvEscape(error || "Pipeline failed"),
+        ].join(","),
+      );
+      continue;
+    }
+
+    if (status === "no_change" || findings.length === 0) {
+      rows.push(
+        [
+          csvEscape(company.company_name),
+          csvEscape("no_change"),
+          "",
+          "",
+          csvEscape("No new signals detected"),
+          "",
+          "",
+          "",
+          "",
+        ].join(","),
+      );
+      continue;
+    }
+
     for (const f of findings) {
       rows.push(
         [
           csvEscape(company.company_name),
+          csvEscape(status),
           csvEscape(getSignalTypeLabel(f.signal_type)),
           csvEscape(f.title),
           csvEscape(f.summary),
           csvEscape(f.source),
           csvEscape(f.url || ""),
           csvEscape(f.detected_at || ""),
+          "",
         ].join(","),
       );
     }
@@ -640,9 +759,48 @@ function buildDigestCSV(digestCompanies: DigestCompany[]): string {
   return rows.join("\n");
 }
 
+export interface DigestEmailPreview {
+  subject: string;
+  html: string;
+  csv: string;
+}
+
+async function buildDigestEmailPreview(
+  digestCompanies: DigestCompany[],
+): Promise<DigestEmailPreview> {
+  const tldr = await generateDigestTldr(digestCompanies);
+  const html = buildDigestEmail(digestCompanies, tldr);
+  const csv = buildDigestCSV(digestCompanies);
+
+  const now = new Date();
+  const dateStr = now.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  const companyNames =
+    digestCompanies.length <= 3
+      ? digestCompanies.map((dc) => dc.company.company_name).join(", ")
+      : `${digestCompanies.length} companies`;
+
+  return {
+    subject: `Daily Delta — ${companyNames} — ${dateStr}`,
+    html,
+    csv,
+  };
+}
+
+export async function previewDigestEmail(
+  digestCompanies: DigestCompany[],
+): Promise<DigestEmailPreview> {
+  return buildDigestEmailPreview(digestCompanies);
+}
+
 export async function sendDigestEmail(
   toEmail: string,
   digestCompanies: DigestCompany[],
+  options?: { idempotencyKey?: string },
 ): Promise<boolean> {
   try {
     const apiKey = process.env.RESEND_API_KEY;
@@ -657,37 +815,28 @@ export async function sendDigestEmail(
       digestCompanies.length, totalSignals, toEmail,
     );
 
-    const tldr = await generateDigestTldr(digestCompanies);
-    const html = buildDigestEmail(digestCompanies, tldr);
-    const csv = buildDigestCSV(digestCompanies);
-
+    const { subject, html, csv } = await buildDigestEmailPreview(
+      digestCompanies,
+    );
     const now = new Date();
-    const dateStr = now.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-
-    const companyNames = digestCompanies.length <= 3
-      ? digestCompanies.map((dc) => dc.company.company_name).join(", ")
-      : `${digestCompanies.length} companies`;
-
-    const subject = `Daily Delta — ${companyNames} — ${dateStr}`;
     const fileDate = now.toISOString().slice(0, 10);
 
     const resend = new Resend(apiKey);
-    const { data, error } = await resend.emails.send({
-      from: `Daily Delta <${fromEmail}>`,
-      to: [toEmail],
-      subject,
-      html,
-      attachments: [
-        {
-          filename: `daily_delta_digest_${fileDate}.csv`,
-          content: Buffer.from(csv).toString("base64"),
-        },
-      ],
-    });
+    const { data, error } = await resend.emails.send(
+      {
+        from: `Daily Delta <${fromEmail}>`,
+        to: [toEmail],
+        subject,
+        html,
+        attachments: [
+          {
+            filename: `daily_delta_digest_${fileDate}.csv`,
+            content: Buffer.from(csv).toString("base64"),
+          },
+        ],
+      },
+      { idempotencyKey: options?.idempotencyKey },
+    );
 
     if (error) {
       throw new Error(`Resend API error: ${error.message}`);

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -3,7 +3,7 @@ import { resolveTemplate, buildGoalFromDefinition } from "@/lib/utils/template";
 import { buildDiscoveryGoal } from "@/services/goals";
 import { startTinyfishAgent, runTinyfishAgentSync, TinyfishCallbacks } from "@/services/tinyfish-client";
 
-interface AgentDefinition {
+export interface PreparedIntelligenceAgent {
   id: string;
   type: string;
   name: string;
@@ -12,10 +12,10 @@ interface AgentDefinition {
   definitionId: string;
 }
 
-function buildAgentsFromDefinitions(
+export function buildAgentsFromDefinitions(
   company: Company,
   definitions: SignalDefinition[],
-): AgentDefinition[] {
+): PreparedIntelligenceAgent[] {
   return definitions
     .filter((def) => def.enabled)
     .map((def) => {

--- a/src/services/pipeline-request-service.ts
+++ b/src/services/pipeline-request-service.ts
@@ -4,7 +4,7 @@ import {
   type PipelineRequestSource,
 } from "@/inngest/events";
 import { createAdminClient } from "@/lib/supabase/admin";
-import type { Company, DigestCompany } from "@/lib/types";
+import type { Company } from "@/lib/types";
 import {
   getCompanyById,
   getCompaniesByIds,
@@ -12,10 +12,9 @@ import {
   getTrackedCompanies,
   getTrackingOrgs,
 } from "@/services/company-service";
-import { sendDigestEmail } from "@/services/email-service";
+import { previewDigestEmail, sendDigestEmail } from "@/services/email-service";
 import { getOrganizationMembers } from "@/services/organization-service";
-import { getDigestCompaniesForReports } from "@/services/report-service";
-import { processCompany } from "@/services/pipeline-service";
+import { getDigestCompaniesForOutcomes } from "@/services/report-service";
 import {
   type EmailFrequency,
   getUserSettings,
@@ -40,6 +39,7 @@ type CompanyPipelineRunStatus = "queued" | "running" | "completed" | "failed";
 interface PipelineRequestRow {
   request_id: string;
   source_event_id: string;
+  request_key: string | null;
   source: PipelineRequestSource;
   status: PipelineRequestStatus;
   requested_company_count: number;
@@ -69,6 +69,8 @@ interface CompanyPipelineRunRow {
   report_id: string | null;
   signal_count: number;
   error: string | null;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface PreparedPipelineRequest {
@@ -80,19 +82,11 @@ export interface PreparedPipelineRequest {
 
 export interface EnqueuePipelineRequestInput {
   source: PipelineRequestSource;
+  requestKey?: string;
   companyIds?: string[];
   organizationId?: string;
   requestedByUserId?: string;
   recipientUserIds?: string[];
-}
-
-export interface ProcessedCompanyRun {
-  companyRunId: string;
-  companyId: string;
-  status: CompanyPipelineRunStatus;
-  signalCount: number;
-  reportId?: string;
-  error?: string;
 }
 
 export interface CompanyRunCompletionEffects {
@@ -100,11 +94,19 @@ export interface CompanyRunCompletionEffects {
   finalizeRequestIds: string[];
 }
 
+export interface PipelineDigestOutcome {
+  companyId: string;
+  reportId?: string | null;
+  status: "completed" | "failed";
+  signalCount: number;
+  error?: string | null;
+}
+
 export interface PipelineDigestDelivery {
   requestId: string;
   orgId: string;
   email: string;
-  reportIds: string[];
+  outcomes: PipelineDigestOutcome[];
 }
 
 export interface PipelineDeliveryPlan {
@@ -114,9 +116,57 @@ export interface PipelineDeliveryPlan {
   deliveries: PipelineDigestDelivery[];
 }
 
+export interface PipelineRequestCompanySummary {
+  companyId: string;
+  companyName: string;
+  status: PipelineRequestCompanyStatus;
+  signalCount: number;
+  reportId: string | null;
+  error: string | null;
+}
+
+export interface PipelineRequestDeliverySummary {
+  orgId: string;
+  email: string;
+  sentAt: string | null;
+}
+
+export interface PipelineRequestSnapshot {
+  requestId: string;
+  requestKey: string | null;
+  source: PipelineRequestSource;
+  status: PipelineRequestStatus;
+  requestedCompanyCount: number;
+  organizationId: string | null;
+  requestedByUserId: string | null;
+  recipientUserIds: string[] | null;
+  allCompaniesTerminal: boolean;
+  previewAvailable: boolean;
+  hadCompanyFailures: boolean;
+  companies: PipelineRequestCompanySummary[];
+  deliveries: PipelineRequestDeliverySummary[];
+}
+
 interface OrgRecipient {
   email: string;
   emailFrequency: EmailFrequency;
+}
+
+interface PipelineRequestDeliveryRow {
+  delivery_id: string;
+  request_id: string;
+  recipient_email: string;
+  sent_at: string | null;
+}
+
+export interface QueuedPipelineRequest {
+  requestId: string | null;
+  requestKey: string | null;
+}
+
+interface EnsuredPipelineRequestShell {
+  request: PipelineRequestRow;
+  created: boolean;
 }
 
 const FREQUENCY_INTERVAL_DAYS: Record<EmailFrequency, number> = {
@@ -132,6 +182,7 @@ const NON_TERMINAL_REQUEST_COMPANY_STATUSES: PipelineRequestCompanyStatus[] = [
   "running",
   "waiting_for_rerun",
 ];
+const STALE_COMPANY_RUN_MS = 20 * 60 * 1000;
 
 function dedupeIds(ids?: string[]): string[] | undefined {
   if (!ids || ids.length === 0) return undefined;
@@ -288,7 +339,7 @@ async function getRequestBySourceEventId(
   const { data, error } = await supabase
     .from("pipeline_requests")
     .select(
-      "request_id, source_event_id, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
+      "request_id, source_event_id, request_key, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
     )
     .eq("source_event_id", sourceEventId)
     .maybeSingle();
@@ -300,8 +351,28 @@ async function getRequestBySourceEventId(
   return (data as PipelineRequestRow | null) ?? null;
 }
 
+async function getRequestByRequestKey(
+  requestKey: string,
+): Promise<PipelineRequestRow | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("pipeline_requests")
+    .select(
+      "request_id, source_event_id, request_key, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
+    )
+    .eq("request_key", requestKey)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load pipeline request by request key: ${error.message}`);
+  }
+
+  return (data as PipelineRequestRow | null) ?? null;
+}
+
 async function createPipelineRequestRow(
   sourceEventId: string,
+  requestKey: string | undefined,
   source: PipelineRequestSource,
   requestedCompanyCount: number,
   metadata?: Pick<
@@ -317,6 +388,7 @@ async function createPipelineRequestRow(
     .from("pipeline_requests")
     .insert({
       source_event_id: sourceEventId,
+      request_key: requestKey ?? null,
       source,
       status,
       requested_company_count: requestedCompanyCount,
@@ -326,7 +398,7 @@ async function createPipelineRequestRow(
       updated_at: new Date().toISOString(),
     })
     .select(
-      "request_id, source_event_id, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
+      "request_id, source_event_id, request_key, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
     )
     .single();
 
@@ -335,6 +407,71 @@ async function createPipelineRequestRow(
   }
 
   return data as PipelineRequestRow;
+}
+
+async function syncPipelineRequestRow(
+  requestId: string,
+  sourceEventId: string,
+  requestedCompanyCount: number,
+  metadata?: Pick<
+    PipelineRequestRow,
+    "organization_id" | "requested_by_user_id" | "recipient_user_ids"
+  >,
+): Promise<void> {
+  const supabase = createAdminClient();
+  const status: PipelineRequestStatus =
+    requestedCompanyCount > 0 ? "running" : "completed";
+
+  const { error } = await supabase
+    .from("pipeline_requests")
+    .update({
+      source_event_id: sourceEventId,
+      status,
+      requested_company_count: requestedCompanyCount,
+      organization_id: metadata?.organization_id ?? null,
+      requested_by_user_id: metadata?.requested_by_user_id ?? null,
+      recipient_user_ids: metadata?.recipient_user_ids ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("request_id", requestId);
+
+  if (error) {
+    throw new Error(`Failed to sync pipeline request: ${error.message}`);
+  }
+}
+
+async function ensurePipelineRequestShell(
+  input: EnqueuePipelineRequestInput,
+) : Promise<EnsuredPipelineRequestShell | null> {
+  if (!input.requestKey) return null;
+
+  const existing = await getRequestByRequestKey(input.requestKey);
+  if (existing) {
+    return {
+      request: existing,
+      created: false,
+    };
+  }
+
+  const normalizedCompanyIds = dedupeIds(input.companyIds) ?? [];
+  return {
+    request: await createPipelineRequestRow(
+      `queued:${input.requestKey}`,
+      input.requestKey,
+      input.source,
+      normalizedCompanyIds.length,
+      {
+        organization_id: input.organizationId ?? null,
+        requested_by_user_id: input.requestedByUserId ?? null,
+        recipient_user_ids:
+          normalizeManualRecipientUserIds(
+            input.requestedByUserId,
+            input.recipientUserIds,
+          ) ?? null,
+      },
+    ),
+    created: true,
+  };
 }
 
 async function listRequestCompanies(
@@ -379,7 +516,7 @@ async function getActiveCompanyRun(
   const { data, error } = await supabase
     .from("company_pipeline_runs")
     .select(
-      "company_run_id, company_id, requested_source, status, rerun_requested, requested_event_sent, report_id, signal_count, error",
+      "company_run_id, company_id, requested_source, status, rerun_requested, requested_event_sent, report_id, signal_count, error, created_at, updated_at",
     )
     .eq("company_id", companyId)
     .in("status", ["queued", "running"])
@@ -408,7 +545,7 @@ async function createCompanyRun(
       updated_at: new Date().toISOString(),
     })
     .select(
-      "company_run_id, company_id, requested_source, status, rerun_requested, requested_event_sent, report_id, signal_count, error",
+      "company_run_id, company_id, requested_source, status, rerun_requested, requested_event_sent, report_id, signal_count, error, created_at, updated_at",
     )
     .single();
 
@@ -419,6 +556,77 @@ async function createCompanyRun(
   return data as CompanyPipelineRunRow;
 }
 
+function isStaleCompanyRun(run: CompanyPipelineRunRow): boolean {
+  const timestamp = run.updated_at ?? run.created_at;
+  if (!timestamp) return false;
+  return Date.now() - new Date(timestamp).getTime() > STALE_COMPANY_RUN_MS;
+}
+
+async function reclaimStaleCompanyRun(
+  run: CompanyPipelineRunRow,
+): Promise<void> {
+  const supabase = createAdminClient();
+  const now = new Date().toISOString();
+  const staleSince = run.updated_at ?? run.created_at ?? now;
+
+  const { error } = await supabase
+    .from("company_pipeline_runs")
+    .update({
+      status: "failed",
+      error: `Stale company run reclaimed after exceeding ${STALE_COMPANY_RUN_MS / 60000} minutes (last activity ${staleSince})`,
+      completed_at: now,
+      updated_at: now,
+    })
+    .eq("company_run_id", run.company_run_id)
+    .in("status", ["queued", "running"]);
+
+  if (error) {
+    throw new Error(`Failed to reclaim stale company pipeline run: ${error.message}`);
+  }
+}
+
+async function reattachRecoveredRequestCompanies(
+  companyId: string,
+  newCompanyRunId: string,
+  reclaimedCompanyRunId: string,
+): Promise<void> {
+  const supabase = createAdminClient();
+  const now = new Date().toISOString();
+
+  const { error: attachedError } = await supabase
+    .from("pipeline_request_companies")
+    .update({
+      company_run_id: newCompanyRunId,
+      status: "queued",
+      updated_at: now,
+    })
+    .eq("company_id", companyId)
+    .eq("company_run_id", reclaimedCompanyRunId)
+    .in("status", ["queued", "running"]);
+
+  if (attachedError) {
+    throw new Error(
+      `Failed to rescue request companies from stale run: ${attachedError.message}`,
+    );
+  }
+
+  const { error: waitingError } = await supabase
+    .from("pipeline_request_companies")
+    .update({
+      company_run_id: newCompanyRunId,
+      status: "queued",
+      updated_at: now,
+    })
+    .eq("company_id", companyId)
+    .eq("status", "waiting_for_rerun");
+
+  if (waitingError) {
+    throw new Error(
+      `Failed to reattach waiting request companies after stale run recovery: ${waitingError.message}`,
+    );
+  }
+}
+
 async function attachRequestCompanyToRun(
   requestId: string,
   companyId: string,
@@ -427,6 +635,13 @@ async function attachRequestCompanyToRun(
   const supabase = createAdminClient();
   const now = new Date().toISOString();
   let activeRun = await getActiveCompanyRun(companyId);
+  let reclaimedRunId: string | null = null;
+
+  if (activeRun && isStaleCompanyRun(activeRun)) {
+    reclaimedRunId = activeRun.company_run_id;
+    await reclaimStaleCompanyRun(activeRun);
+    activeRun = await getActiveCompanyRun(companyId);
+  }
 
   if (!activeRun) {
     try {
@@ -440,11 +655,24 @@ async function attachRequestCompanyToRun(
         );
       }
       activeRun = await getActiveCompanyRun(companyId);
+      if (activeRun && isStaleCompanyRun(activeRun)) {
+        reclaimedRunId = activeRun.company_run_id;
+        await reclaimStaleCompanyRun(activeRun);
+        activeRun = await createCompanyRun(companyId, source);
+      }
     }
   }
 
   if (!activeRun) {
     throw new Error(`Failed to attach company ${companyId} to an active run`);
+  }
+
+  if (reclaimedRunId) {
+    await reattachRecoveredRequestCompanies(
+      companyId,
+      activeRun.company_run_id,
+      reclaimedRunId,
+    );
   }
 
   if (activeRun.status === "running") {
@@ -552,11 +780,22 @@ export async function markCompanyRunsRequested(
 
 export async function enqueuePipelineRequestedEvent(
   input: EnqueuePipelineRequestInput,
-): Promise<void> {
+): Promise<QueuedPipelineRequest> {
+  const shell = await ensurePipelineRequestShell(input);
+
+  if (shell && !shell.created) {
+    return {
+      requestId: shell.request.request_id,
+      requestKey: shell.request.request_key ?? input.requestKey ?? null,
+    };
+  }
+
   await inngest.send({
     name: PIPELINE_REQUESTED_EVENT,
     data: {
       source: input.source,
+      requestId: shell?.request.request_id,
+      requestKey: input.requestKey,
       companyIds: dedupeIds(input.companyIds),
       organizationId: input.organizationId,
       requestedByUserId: input.requestedByUserId,
@@ -566,11 +805,18 @@ export async function enqueuePipelineRequestedEvent(
       ),
     },
   });
+
+  return {
+    requestId: shell?.request.request_id ?? null,
+    requestKey: shell?.request.request_key ?? input.requestKey ?? null,
+  };
 }
 
 export async function preparePipelineRequest(
   sourceEventId: string,
   source: PipelineRequestSource,
+  requestId?: string,
+  requestKey?: string,
   requestedCompanyIds?: string[],
   metadata?: {
     organizationId?: string;
@@ -589,14 +835,30 @@ export async function preparePipelineRequest(
   );
   const companyIds = [...new Set(companies.map((company) => company.company_id))];
 
-  let request = await getRequestBySourceEventId(sourceEventId);
+  let request = requestId
+    ? await getPipelineRequestById(requestId)
+    : requestKey
+      ? await getRequestByRequestKey(requestKey)
+      : await getRequestBySourceEventId(sourceEventId);
   if (!request) {
-    request = await createPipelineRequestRow(sourceEventId, source, companyIds.length, {
-      organization_id: metadata?.organizationId ?? null,
-      requested_by_user_id: metadata?.requestedByUserId ?? null,
-      recipient_user_ids: normalizedRecipientUserIds ?? null,
-    });
+    request = await createPipelineRequestRow(
+      sourceEventId,
+      requestKey,
+      source,
+      companyIds.length,
+      {
+        organization_id: metadata?.organizationId ?? null,
+        requested_by_user_id: metadata?.requestedByUserId ?? null,
+        recipient_user_ids: normalizedRecipientUserIds ?? null,
+      },
+    );
   }
+
+  await syncPipelineRequestRow(request.request_id, sourceEventId, companyIds.length, {
+    organization_id: metadata?.organizationId ?? null,
+    requested_by_user_id: metadata?.requestedByUserId ?? null,
+    recipient_user_ids: normalizedRecipientUserIds ?? null,
+  });
 
   if (companyIds.length === 0) {
     return {
@@ -641,7 +903,7 @@ async function getCompanyRunById(
   const { data, error } = await supabase
     .from("company_pipeline_runs")
     .select(
-      "company_run_id, company_id, requested_source, status, rerun_requested, requested_event_sent, report_id, signal_count, error",
+      "company_run_id, company_id, requested_source, status, rerun_requested, requested_event_sent, report_id, signal_count, error, created_at, updated_at",
     )
     .eq("company_run_id", companyRunId)
     .maybeSingle();
@@ -685,91 +947,6 @@ async function markCompanyRunRunning(companyRunId: string): Promise<void> {
       `Failed to mark request companies running: ${requestError.message}`,
     );
   }
-}
-
-export async function processQueuedCompanyRun(
-  companyRunId: string,
-): Promise<ProcessedCompanyRun> {
-  const supabase = createAdminClient();
-  const companyRun = await getCompanyRunById(companyRunId);
-
-  if (!companyRun) {
-    throw new Error(`Company pipeline run ${companyRunId} not found`);
-  }
-
-  if (companyRun.status === "completed" || companyRun.status === "failed") {
-    return {
-      companyRunId: companyRun.company_run_id,
-      companyId: companyRun.company_id,
-      status: companyRun.status,
-      signalCount: companyRun.signal_count,
-      reportId: companyRun.report_id ?? undefined,
-      error: companyRun.error ?? undefined,
-    };
-  }
-
-  if (companyRun.status === "queued") {
-    await markCompanyRunRunning(companyRunId);
-  }
-
-  const company = await getCompanyById(companyRun.company_id);
-  if (!company) {
-    const message = `Company ${companyRun.company_id} not found`;
-    const now = new Date().toISOString();
-    const { error } = await supabase
-      .from("company_pipeline_runs")
-      .update({
-        status: "failed",
-        error: message,
-        completed_at: now,
-        updated_at: now,
-      })
-      .eq("company_run_id", companyRunId);
-
-    if (error) {
-      throw new Error(`Failed to store missing company failure: ${error.message}`);
-    }
-
-    return {
-      companyRunId,
-      companyId: companyRun.company_id,
-      status: "failed",
-      signalCount: 0,
-      error: message,
-    };
-  }
-
-  const result = await processCompany(
-    company,
-    mapSourceToReportTrigger(companyRun.requested_source),
-  );
-
-  const terminalStatus: CompanyPipelineRunStatus = result.error ? "failed" : "completed";
-  const now = new Date().toISOString();
-  const { error } = await supabase
-    .from("company_pipeline_runs")
-    .update({
-      status: terminalStatus,
-      report_id: result.reportId ?? null,
-      signal_count: result.signalCount,
-      error: result.error ?? null,
-      completed_at: now,
-      updated_at: now,
-    })
-    .eq("company_run_id", companyRunId);
-
-  if (error) {
-    throw new Error(`Failed to store company run result: ${error.message}`);
-  }
-
-  return {
-    companyRunId,
-    companyId: result.companyId,
-    status: terminalStatus,
-    signalCount: result.signalCount,
-    reportId: result.reportId,
-    error: result.error,
-  };
 }
 
 async function determineSuccessorSource(
@@ -972,7 +1149,7 @@ async function getPipelineRequestById(
   const { data, error } = await supabase
     .from("pipeline_requests")
     .select(
-      "request_id, source_event_id, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
+      "request_id, source_event_id, request_key, source, status, requested_company_count, organization_id, requested_by_user_id, recipient_user_ids",
     )
     .eq("request_id", requestId)
     .maybeSingle();
@@ -982,6 +1159,154 @@ async function getPipelineRequestById(
   }
 
   return (data as PipelineRequestRow | null) ?? null;
+}
+
+async function getLastSentDigestAt(
+  recipientEmail: string,
+  source: PipelineRequestSource,
+): Promise<string | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("pipeline_request_deliveries")
+    .select("sent_at, pipeline_requests!inner(source)")
+    .eq("recipient_email", recipientEmail)
+    .eq("pipeline_requests.source", source)
+    .not("sent_at", "is", null)
+    .order("sent_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load last sent digest timestamp: ${error.message}`);
+  }
+
+  return (data as { sent_at: string | null } | null)?.sent_at ?? null;
+}
+
+async function ensurePipelineRequestDeliveries(
+  requestId: string,
+  recipientEmails: string[],
+): Promise<void> {
+  if (recipientEmails.length === 0) return;
+
+  const supabase = createAdminClient();
+  await Promise.all(
+    recipientEmails.map(async (recipientEmail) => {
+      const { error } = await supabase.from("pipeline_request_deliveries").insert({
+        request_id: requestId,
+        recipient_email: recipientEmail,
+        updated_at: new Date().toISOString(),
+      });
+
+      if (error && !isUniqueViolation(error)) {
+        throw new Error(`Failed to create pipeline delivery row: ${error.message}`);
+      }
+    }),
+  );
+}
+
+async function getPipelineRequestDelivery(
+  requestId: string,
+  recipientEmail: string,
+): Promise<PipelineRequestDeliveryRow | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("pipeline_request_deliveries")
+    .select("delivery_id, request_id, recipient_email, sent_at")
+    .eq("request_id", requestId)
+    .eq("recipient_email", recipientEmail)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load pipeline delivery row: ${error.message}`);
+  }
+
+  return (data as PipelineRequestDeliveryRow | null) ?? null;
+}
+
+async function listPipelineRequestDeliveries(
+  requestId: string,
+  recipientEmails?: string[],
+): Promise<PipelineRequestDeliveryRow[]> {
+  if (recipientEmails && recipientEmails.length === 0) {
+    return [];
+  }
+
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("pipeline_request_deliveries")
+    .select("delivery_id, request_id, recipient_email, sent_at")
+    .eq("request_id", requestId);
+
+  if (recipientEmails) {
+    query = query.in("recipient_email", recipientEmails);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(`Failed to list pipeline deliveries: ${error.message}`);
+  }
+
+  return (data ?? []) as PipelineRequestDeliveryRow[];
+}
+
+async function markPipelineRequestDeliverySent(
+  requestId: string,
+  recipientEmail: string,
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("pipeline_request_deliveries")
+    .update({
+      sent_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("request_id", requestId)
+    .eq("recipient_email", recipientEmail)
+    .is("sent_at", null);
+
+  if (error) {
+    throw new Error(`Failed to mark pipeline delivery as sent: ${error.message}`);
+  }
+}
+
+function toPipelineDigestOutcome(
+  row: PipelineRequestCompanyRow,
+): PipelineDigestOutcome {
+  if (row.status !== "completed" && row.status !== "failed") {
+    throw new Error(
+      `Cannot build a digest outcome from non-terminal request company status: ${row.status}`,
+    );
+  }
+
+  return {
+    companyId: row.company_id,
+    reportId: row.report_id,
+    status: row.status,
+    signalCount: row.signal_count,
+    error: row.error,
+  };
+}
+
+async function getScopedRequestCompanyRows(
+  request: PipelineRequestRow,
+  requestCompanies: PipelineRequestCompanyRow[],
+  organizationId: string,
+): Promise<PipelineRequestCompanyRow[]> {
+  if (request.organization_id) {
+    if (request.organization_id !== organizationId) {
+      return [];
+    }
+
+    return requestCompanies;
+  }
+
+  const trackedCompanies = await getTrackedCompanies(organizationId);
+  const trackedCompanyIds = new Set(
+    trackedCompanies.map((company) => company.company_id),
+  );
+
+  return requestCompanies.filter((row) => trackedCompanyIds.has(row.company_id));
 }
 
 export async function buildPipelineDeliveryPlan(
@@ -1006,14 +1331,7 @@ export async function buildPipelineDeliveryPlan(
     };
   }
 
-  const successfulRows = requestCompanies.filter(
-    (row) =>
-      row.status === "completed" &&
-      !!row.report_id &&
-      row.signal_count > 0,
-  );
-
-  if (successfulRows.length === 0) {
+  if (requestCompanies.length === 0) {
     return {
       requestId,
       source: request.source,
@@ -1041,52 +1359,48 @@ export async function buildPipelineDeliveryPlan(
         requestId,
         orgId: request.organization_id!,
         email,
-        reportIds: [...new Set(successfulRows.map((row) => row.report_id!))],
+        outcomes: requestCompanies.map(toPipelineDigestOutcome),
       })),
     };
   }
 
   const orgIdsByCompanyId = new Map<string, string[]>();
   await Promise.all(
-    successfulRows.map(async (row) => {
+    requestCompanies.map(async (row) => {
       orgIdsByCompanyId.set(row.company_id, await getTrackingOrgs(row.company_id));
     }),
   );
 
-  const reportIdsByOrgId = new Map<string, string[]>();
-  for (const row of successfulRows) {
-    const reportId = row.report_id!;
+  const outcomesByOrgId = new Map<string, PipelineDigestOutcome[]>();
+  for (const row of requestCompanies) {
     const orgIds = orgIdsByCompanyId.get(row.company_id) ?? [];
     for (const orgId of orgIds) {
-      if (!reportIdsByOrgId.has(orgId)) {
-        reportIdsByOrgId.set(orgId, []);
+      if (!outcomesByOrgId.has(orgId)) {
+        outcomesByOrgId.set(orgId, []);
       }
-      reportIdsByOrgId.get(orgId)!.push(reportId);
+      outcomesByOrgId.get(orgId)!.push(toPipelineDigestOutcome(row));
     }
   }
 
   const deliveries: PipelineDigestDelivery[] = [];
-  for (const [orgId, reportIds] of reportIdsByOrgId) {
+  for (const [orgId, outcomes] of outcomesByOrgId) {
     const recipients = await getOrgRecipientEmails(orgId);
     if (recipients.length === 0) continue;
 
     let allowedRecipients = recipients;
     if (request.source === "cron") {
-      const trackedCompanies = await getTrackedCompanies(orgId);
-      const orgLastRun = trackedCompanies.reduce<string | null>(
-        (earliest, trackedCompany) => {
-          if (!trackedCompany.last_agent_run) return earliest;
-          if (!earliest) return trackedCompany.last_agent_run;
-          return trackedCompany.last_agent_run < earliest
-            ? trackedCompany.last_agent_run
-            : earliest;
-        },
-        null,
+      const recipientChecks = await Promise.all(
+        recipients.map(async (recipient) => ({
+          recipient,
+          lastSentAt: await getLastSentDigestAt(recipient.email, "cron"),
+        })),
       );
 
-      allowedRecipients = recipients.filter((recipient) =>
-        shouldRunToday(recipient.emailFrequency, orgLastRun),
-      );
+      allowedRecipients = recipientChecks
+        .filter(({ recipient, lastSentAt }) =>
+          shouldRunToday(recipient.emailFrequency, lastSentAt),
+        )
+        .map(({ recipient }) => recipient);
     }
 
     for (const recipient of allowedRecipients) {
@@ -1094,7 +1408,7 @@ export async function buildPipelineDeliveryPlan(
         requestId,
         orgId,
         email: recipient.email,
-        reportIds: [...new Set(reportIds)],
+        outcomes,
       });
     }
   }
@@ -1107,15 +1421,169 @@ export async function buildPipelineDeliveryPlan(
   };
 }
 
+export async function getPipelineRequestSnapshot(
+  requestId: string,
+  organizationId: string,
+): Promise<PipelineRequestSnapshot | null> {
+  const request = await getPipelineRequestById(requestId);
+  if (!request) {
+    return null;
+  }
+
+  const requestCompanies = await listRequestCompanies(requestId);
+  const scopedRequestCompanies = await getScopedRequestCompanyRows(
+    request,
+    requestCompanies,
+    organizationId,
+  );
+
+  if (scopedRequestCompanies.length === 0) {
+    return null;
+  }
+
+  const companies = await getCompaniesByIds(
+    scopedRequestCompanies.map((row) => row.company_id),
+  );
+  const companyById = new Map(
+    companies.map((company) => [company.company_id, company.company_name]),
+  );
+
+  const allCompaniesTerminal = scopedRequestCompanies.every(
+    (row) => row.status === "completed" || row.status === "failed",
+  );
+  const hadCompanyFailures = scopedRequestCompanies.some(
+    (row) => row.status === "failed" || !!row.error,
+  );
+
+  let deliveries: PipelineRequestDeliverySummary[] = [];
+  if (allCompaniesTerminal) {
+    const orgRecipientEmails =
+      request.source === "manual" &&
+      request.organization_id &&
+      request.requested_by_user_id
+        ? request.organization_id === organizationId
+          ? await getScopedManualRecipientEmails(
+              request.organization_id,
+              request.requested_by_user_id,
+              request.recipient_user_ids ?? undefined,
+            )
+          : []
+        : (await getOrgRecipientEmails(organizationId)).map(
+            (recipient) => recipient.email,
+          );
+
+    const deliveryRows = await listPipelineRequestDeliveries(
+      requestId,
+      [...new Set(orgRecipientEmails)],
+    );
+
+    if (deliveryRows.length > 0) {
+      deliveries = deliveryRows.map((delivery) => ({
+        orgId: organizationId,
+        email: delivery.recipient_email,
+        sentAt: delivery.sent_at,
+      }));
+    } else {
+      const deliveryPlan = await buildPipelineDeliveryPlan(requestId);
+      const scopedDeliveries = deliveryPlan.deliveries.filter(
+        (delivery) => delivery.orgId === organizationId,
+      );
+
+      deliveries = scopedDeliveries.map((delivery) => ({
+        orgId: delivery.orgId,
+        email: delivery.email,
+        sentAt: null,
+      }));
+    }
+  }
+
+  return {
+    requestId: request.request_id,
+    requestKey: request.request_key,
+    source: request.source,
+    status: request.status,
+    requestedCompanyCount: request.requested_company_count,
+    organizationId: request.organization_id,
+    requestedByUserId: request.requested_by_user_id,
+    recipientUserIds: request.recipient_user_ids,
+    allCompaniesTerminal,
+    previewAvailable: allCompaniesTerminal && scopedRequestCompanies.length > 0,
+    hadCompanyFailures,
+    companies: scopedRequestCompanies.map((row) => ({
+      companyId: row.company_id,
+      companyName: companyById.get(row.company_id) ?? "Unknown company",
+      status: row.status,
+      signalCount: row.signal_count,
+      reportId: row.report_id,
+      error: row.error,
+    })),
+    deliveries,
+  };
+}
+
+export async function previewPipelineRequestDigest(
+  requestId: string,
+  organizationId: string,
+): Promise<{ subject: string; html: string } | null> {
+  const snapshot = await getPipelineRequestSnapshot(requestId, organizationId);
+  if (!snapshot) {
+    return null;
+  }
+
+  if (!snapshot.allCompaniesTerminal) {
+    throw new Error(`Pipeline request ${requestId} is still running`);
+  }
+
+  const digestCompanies = await getDigestCompaniesForOutcomes(
+    snapshot.companies.map((company) => ({
+      companyId: company.companyId,
+      reportId: company.reportId,
+      status: company.status === "failed" ? "failed" : "completed",
+      signalCount: company.signalCount,
+      error: company.error,
+    })),
+  );
+
+  if (digestCompanies.length === 0) {
+    return null;
+  }
+
+  const preview = await previewDigestEmail(digestCompanies);
+  return {
+    subject: preview.subject,
+    html: preview.html,
+  };
+}
+
 export async function sendPipelineDigestDelivery(
   delivery: PipelineDigestDelivery,
 ): Promise<{ email: string; sent: boolean }> {
-  const digestCompanies = await getDigestCompaniesForReports(delivery.reportIds);
+  if (delivery.outcomes.length === 0) {
+    return { email: delivery.email, sent: false };
+  }
+
+  await ensurePipelineRequestDeliveries(delivery.requestId, [delivery.email]);
+  const existingDelivery = await getPipelineRequestDelivery(
+    delivery.requestId,
+    delivery.email,
+  );
+
+  if (existingDelivery?.sent_at) {
+    return { email: delivery.email, sent: true };
+  }
+
+  const digestCompanies = await getDigestCompaniesForOutcomes(delivery.outcomes);
   if (digestCompanies.length === 0) {
     return { email: delivery.email, sent: false };
   }
 
-  const sent = await sendDigestEmail(delivery.email, digestCompanies);
+  const sent = await sendDigestEmail(delivery.email, digestCompanies, {
+    idempotencyKey: `pipeline-request:${delivery.requestId}:${delivery.email}`,
+  });
+  if (sent) {
+    await markPipelineRequestDeliverySent(delivery.requestId, delivery.email);
+  }
+
   return { email: delivery.email, sent };
 }
 
@@ -1143,10 +1611,4 @@ export async function markPipelineRequestFinalized(
   if (error) {
     throw new Error(`Failed to finalize pipeline request: ${error.message}`);
   }
-}
-
-export async function buildDigestCompaniesForReports(
-  reportIds: string[],
-): Promise<DigestCompany[]> {
-  return getDigestCompaniesForReports(reportIds);
 }

--- a/src/services/pipeline-service.ts
+++ b/src/services/pipeline-service.ts
@@ -1,16 +1,27 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateText } from "ai";
-import type { Company, SignalFinding, CompanyPipelineResult } from "@/lib/types";
+import type {
+  Company,
+  SignalFinding,
+  CompanyPipelineResult,
+  SignalDefinition,
+} from "@/lib/types";
 import {
   updateLastAgentRun,
+  getCompanyById,
 } from "@/services/company-service";
-import { runIntelligenceAgentsSilent } from "@/services/orchestrator";
+import {
+  buildAgentsFromDefinitions,
+  type PreparedIntelligenceAgent,
+  runIntelligenceAgentsSilent,
+} from "@/services/orchestrator";
 import {
   generateReportFromFindings,
   storeReport,
 } from "@/services/report-service";
 import { getSignalDefinitions } from "@/services/signal-definition-service";
+import { getTinyfishRun, queueTinyfishAgent } from "@/services/tinyfish-client";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -363,4 +374,611 @@ export async function processCompany(
       findings: [],
     };
   }
+}
+
+type CompanyPipelineRunStatus = "queued" | "running" | "completed" | "failed";
+type CompanyAgentRunStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+interface CompanyPipelineRunRow {
+  company_run_id: string;
+  company_id: string;
+  requested_source: "cron" | "manual" | "refresh";
+  status: CompanyPipelineRunStatus;
+  report_id: string | null;
+  signal_count: number;
+  error: string | null;
+}
+
+interface CompanyAgentRunRow {
+  agent_run_id: string;
+  company_run_id: string;
+  company_id: string;
+  agent_name: string;
+  definition_id: string | null;
+  tinyfish_run_id: string | null;
+  status: CompanyAgentRunStatus;
+  findings: unknown;
+  error: unknown;
+}
+
+export interface SubmittedCompanyAgents {
+  companyRunId: string;
+  companyId: string;
+  agentCount: number;
+}
+
+export interface PolledCompanyAgents {
+  companyRunId: string;
+  companyId: string;
+  terminal: boolean;
+  pendingCount: number;
+  completedCount: number;
+  failedCount: number;
+}
+
+export interface FinalizedCompanyRun {
+  companyRunId: string;
+  companyId: string;
+  status: "completed" | "failed";
+  signalCount: number;
+  reportId?: string;
+  error?: string;
+}
+
+function toReportTrigger(source: "cron" | "manual" | "refresh"): "manual" | "cron" {
+  return source === "cron" ? "cron" : "manual";
+}
+
+function readAgentErrorMessage(error: unknown): string {
+  if (!error) return "Unknown agent failure";
+  if (typeof error === "string") return error;
+  if (typeof error === "object") {
+    if (
+      "message" in error &&
+      typeof (error as { message?: unknown }).message === "string"
+    ) {
+      return (error as { message: string }).message;
+    }
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return "Unknown agent failure";
+    }
+  }
+  return String(error);
+}
+
+function parseTinyfishFindings(
+  raw: unknown,
+  definitionId?: string | null,
+): { findings: SignalFinding[]; error?: string } {
+  let parsed = raw;
+
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch (error) {
+      return {
+        findings: [],
+        error: `Malformed TinyFish JSON result: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return { findings: [] };
+  }
+
+  const maybeSignals = (parsed as { signals?: unknown }).signals;
+  if (maybeSignals == null) {
+    return { findings: [] };
+  }
+
+  if (!Array.isArray(maybeSignals)) {
+    return {
+      findings: [],
+      error: "TinyFish result did not contain a signals array",
+    };
+  }
+
+  const findings = maybeSignals.flatMap((value) => {
+    if (!value || typeof value !== "object") return [];
+
+    const record = value as Record<string, unknown>;
+    const title = typeof record.title === "string" ? record.title : "";
+    const summary = typeof record.summary === "string" ? record.summary : "";
+    if (!title || !summary) return [];
+
+    return [
+      {
+        signal_type:
+          typeof record.signal_type === "string"
+            ? record.signal_type
+            : "general_news",
+        title,
+        summary,
+        source: typeof record.source === "string" ? record.source : "unknown",
+        url: typeof record.url === "string" ? record.url : undefined,
+        detected_at:
+          typeof record.detected_at === "string"
+            ? record.detected_at
+            : undefined,
+        signal_definition_id:
+          typeof record.signal_definition_id === "string"
+            ? record.signal_definition_id
+            : definitionId ?? undefined,
+      } satisfies SignalFinding,
+    ];
+  });
+
+  return { findings };
+}
+
+async function getCompanyPipelineRun(
+  companyRunId: string,
+): Promise<CompanyPipelineRunRow | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("company_pipeline_runs")
+    .select(
+      "company_run_id, company_id, requested_source, status, report_id, signal_count, error",
+    )
+    .eq("company_run_id", companyRunId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load company pipeline run: ${error.message}`);
+  }
+
+  return (data as CompanyPipelineRunRow | null) ?? null;
+}
+
+async function listCompanyAgentRuns(
+  companyRunId: string,
+): Promise<CompanyAgentRunRow[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("company_agent_runs")
+    .select(
+      "agent_run_id, company_run_id, company_id, agent_name, definition_id, tinyfish_run_id, status, findings, error",
+    )
+    .eq("company_run_id", companyRunId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load company agent runs: ${error.message}`);
+  }
+
+  return (data ?? []) as CompanyAgentRunRow[];
+}
+
+async function markCompanyRunState(
+  companyRunId: string,
+  fields: Record<string, unknown>,
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("company_pipeline_runs")
+    .update({
+      ...fields,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("company_run_id", companyRunId);
+
+  if (error) {
+    throw new Error(`Failed to update company pipeline run: ${error.message}`);
+  }
+}
+
+export async function failCompanyRun(
+  companyRunId: string,
+  errorMessage: string,
+): Promise<FinalizedCompanyRun> {
+  const companyRun = await getCompanyPipelineRun(companyRunId);
+  if (!companyRun) {
+    throw new Error(`Company pipeline run ${companyRunId} not found`);
+  }
+
+  if (companyRun.status === "completed" || companyRun.status === "failed") {
+    return {
+      companyRunId,
+      companyId: companyRun.company_id,
+      status: companyRun.status,
+      signalCount: companyRun.signal_count,
+      reportId: companyRun.report_id ?? undefined,
+      error: companyRun.error ?? errorMessage,
+    };
+  }
+
+  await markCompanyRunState(companyRunId, {
+    status: "failed",
+    signal_count: 0,
+    report_id: null,
+    error: errorMessage,
+    completed_at: new Date().toISOString(),
+  });
+
+  return {
+    companyRunId,
+    companyId: companyRun.company_id,
+    status: "failed",
+    signalCount: 0,
+    error: errorMessage,
+  };
+}
+
+async function persistCompanyFindings(
+  company: Company,
+  definitions: SignalDefinition[],
+  trigger: "manual" | "cron",
+  findings: SignalFinding[],
+): Promise<CompanyPipelineResult> {
+  const tag = `[PIPELINE] [${company.company_name}]`;
+
+  const newFindings = await deduplicateFindings(company.company_id, findings);
+  console.log(
+    "%s After fast dedup: %d new signals (filtered %d duplicates)",
+    tag,
+    newFindings.length,
+    findings.length - newFindings.length,
+  );
+
+  const finalFindings = await llmDedup(company.company_id, newFindings);
+  console.log(
+    "%s After LLM dedup: %d signals (filtered %d more)",
+    tag,
+    finalFindings.length,
+    newFindings.length - finalFindings.length,
+  );
+
+  if (finalFindings.length > 0) {
+    await storeSignals(company.company_id, finalFindings);
+    console.log("%s Stored %d signals", tag, finalFindings.length);
+
+    const reportData = generateReportFromFindings(company, finalFindings, definitions);
+    const report = await storeReport(company.company_id, reportData, trigger);
+    console.log("%s Report stored (%d sections)", tag, reportData.sections.length);
+
+    await updateLastAgentRun(company.company_id);
+
+    return {
+      companyId: company.company_id,
+      companyName: company.company_name,
+      signalCount: finalFindings.length,
+      reportId: report.report_id,
+      findings: finalFindings,
+    };
+  }
+
+  await updateLastAgentRun(company.company_id);
+
+  return {
+    companyId: company.company_id,
+    companyName: company.company_name,
+    signalCount: 0,
+    findings: [],
+  };
+}
+
+export async function submitCompanyAgents(
+  companyRunId: string,
+): Promise<SubmittedCompanyAgents> {
+  const companyRun = await getCompanyPipelineRun(companyRunId);
+  if (!companyRun) {
+    throw new Error(`Company pipeline run ${companyRunId} not found`);
+  }
+
+  if (companyRun.status === "queued") {
+    const now = new Date().toISOString();
+    await markCompanyRunState(companyRunId, {
+      status: "running",
+      started_at: now,
+    });
+
+    const supabase = createAdminClient();
+    const { error: requestCompanyError } = await supabase
+      .from("pipeline_request_companies")
+      .update({
+        status: "running",
+        updated_at: now,
+      })
+      .eq("company_run_id", companyRunId)
+      .eq("status", "queued");
+
+    if (requestCompanyError) {
+      throw new Error(
+        `Failed to mark request companies running: ${requestCompanyError.message}`,
+      );
+    }
+  }
+
+  const company = await getCompanyById(companyRun.company_id);
+  if (!company) {
+    await markCompanyRunState(companyRunId, {
+      status: "failed",
+      completed_at: new Date().toISOString(),
+      error: `Company ${companyRun.company_id} not found`,
+    });
+
+    return {
+      companyRunId,
+      companyId: companyRun.company_id,
+      agentCount: 0,
+    };
+  }
+
+  const definitions = await getSignalDefinitions(company.company_id);
+  const enabledDefinitions = definitions.filter((definition) => definition.enabled);
+  const agents = buildAgentsFromDefinitions(company, enabledDefinitions);
+  const existingRuns = await listCompanyAgentRuns(companyRunId);
+  const existingDefinitionIds = new Set(
+    existingRuns
+      .map((run) => run.definition_id)
+      .filter((definitionId): definitionId is string => !!definitionId),
+  );
+
+  const agentsToSubmit = agents.filter(
+    (agent) => !existingDefinitionIds.has(agent.definitionId),
+  );
+
+  const supabase = createAdminClient();
+  await Promise.all(
+    agentsToSubmit.map(async (agent) => {
+      const queued = await queueTinyfishAgent({ url: agent.url, goal: agent.goal });
+      const payload = {
+        company_run_id: companyRunId,
+        company_id: company.company_id,
+        agent_name: agent.name,
+        definition_id: agent.definitionId,
+        tinyfish_run_id: queued.run_id,
+        status: queued.status,
+        error: queued.error,
+        updated_at: new Date().toISOString(),
+      };
+
+      const { error } = await supabase.from("company_agent_runs").insert(payload);
+      if (error) {
+        throw new Error(`Failed to create company agent run: ${error.message}`);
+      }
+    }),
+  );
+
+  return {
+    companyRunId,
+    companyId: company.company_id,
+    agentCount: agents.length,
+  };
+}
+
+export async function pollCompanyAgents(
+  companyRunId: string,
+): Promise<PolledCompanyAgents> {
+  const companyRun = await getCompanyPipelineRun(companyRunId);
+  if (!companyRun) {
+    throw new Error(`Company pipeline run ${companyRunId} not found`);
+  }
+
+  const supabase = createAdminClient();
+  const agentRuns = await listCompanyAgentRuns(companyRunId);
+
+  await Promise.all(
+    agentRuns.map(async (agentRun) => {
+      if (agentRun.status === "completed" || agentRun.status === "failed" || agentRun.status === "canceled") {
+        return;
+      }
+
+      if (!agentRun.tinyfish_run_id) {
+        const { error } = await supabase
+          .from("company_agent_runs")
+          .update({
+            status: "failed",
+            error: { code: "MISSING_RUN_ID", message: "TinyFish run ID is missing" },
+            completed_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("agent_run_id", agentRun.agent_run_id);
+
+        if (error) {
+          throw new Error(`Failed to mark missing TinyFish run ID: ${error.message}`);
+        }
+        return;
+      }
+
+      let status;
+      try {
+        status = await getTinyfishRun(agentRun.tinyfish_run_id);
+      } catch (error) {
+        console.warn(
+          "[PIPELINE] Failed to poll TinyFish run %s: %s",
+          agentRun.tinyfish_run_id,
+          error instanceof Error ? error.message : String(error),
+        );
+        return;
+      }
+
+      const nextStatus = status.status;
+      if (nextStatus === "completed") {
+        const parsed = parseTinyfishFindings(status.result, agentRun.definition_id);
+        if (parsed.error) {
+          const { error } = await supabase
+            .from("company_agent_runs")
+            .update({
+              status: "failed",
+              error: { code: "MALFORMED_RESULT", message: parsed.error },
+              completed_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            })
+            .eq("agent_run_id", agentRun.agent_run_id);
+
+          if (error) {
+            throw new Error(`Failed to persist malformed TinyFish result: ${error.message}`);
+          }
+          return;
+        }
+
+        const { error } = await supabase
+          .from("company_agent_runs")
+          .update({
+            status: "completed",
+            findings: parsed.findings,
+            error: null,
+            completed_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("agent_run_id", agentRun.agent_run_id);
+
+        if (error) {
+          throw new Error(`Failed to persist completed TinyFish run: ${error.message}`);
+        }
+        return;
+      }
+
+      if (nextStatus === "failed" || nextStatus === "canceled") {
+        const { error } = await supabase
+          .from("company_agent_runs")
+          .update({
+            status: nextStatus,
+            error: status.error,
+            completed_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("agent_run_id", agentRun.agent_run_id);
+
+        if (error) {
+          throw new Error(`Failed to persist failed TinyFish run: ${error.message}`);
+        }
+        return;
+      }
+
+      const { error } = await supabase
+        .from("company_agent_runs")
+        .update({
+          status: nextStatus,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("agent_run_id", agentRun.agent_run_id);
+
+      if (error) {
+        throw new Error(`Failed to persist TinyFish run status: ${error.message}`);
+      }
+    }),
+  );
+
+  const refreshedRuns = await listCompanyAgentRuns(companyRunId);
+  const pendingCount = refreshedRuns.filter(
+    (run) => run.status === "queued" || run.status === "running",
+  ).length;
+  const completedCount = refreshedRuns.filter((run) => run.status === "completed").length;
+  const failedCount = refreshedRuns.filter(
+    (run) => run.status === "failed" || run.status === "canceled",
+  ).length;
+
+  return {
+    companyRunId,
+    companyId: companyRun.company_id,
+    terminal: pendingCount === 0,
+    pendingCount,
+    completedCount,
+    failedCount,
+  };
+}
+
+export async function finalizeCompanyAgents(
+  companyRunId: string,
+): Promise<FinalizedCompanyRun> {
+  const companyRun = await getCompanyPipelineRun(companyRunId);
+  if (!companyRun) {
+    throw new Error(`Company pipeline run ${companyRunId} not found`);
+  }
+
+  const company = await getCompanyById(companyRun.company_id);
+  if (!company) {
+    const errorMessage = `Company ${companyRun.company_id} not found`;
+    await markCompanyRunState(companyRunId, {
+      status: "failed",
+      completed_at: new Date().toISOString(),
+      error: errorMessage,
+    });
+
+    return {
+      companyRunId,
+      companyId: companyRun.company_id,
+      status: "failed",
+      signalCount: 0,
+      error: errorMessage,
+    };
+  }
+
+  const agentRuns = await listCompanyAgentRuns(companyRunId);
+  const pendingCount = agentRuns.filter(
+    (run) => run.status === "queued" || run.status === "running",
+  ).length;
+
+  if (pendingCount > 0) {
+    throw new Error(`Company run ${companyRunId} still has ${pendingCount} active agent runs`);
+  }
+
+  const definitions = await getSignalDefinitions(company.company_id);
+  const completedRuns = agentRuns.filter((run) => run.status === "completed");
+  const failedRuns = agentRuns.filter(
+    (run) => run.status === "failed" || run.status === "canceled",
+  );
+  const findings = completedRuns.flatMap((run) =>
+    Array.isArray(run.findings) ? (run.findings as SignalFinding[]) : [],
+  );
+
+  if (completedRuns.length > 0 || agentRuns.length === 0) {
+    const result = await persistCompanyFindings(
+      company,
+      definitions,
+      toReportTrigger(companyRun.requested_source),
+      findings,
+    );
+
+    await markCompanyRunState(companyRunId, {
+      status: "completed",
+      report_id: result.reportId ?? null,
+      signal_count: result.signalCount,
+      error: null,
+      completed_at: new Date().toISOString(),
+    });
+
+    return {
+      companyRunId,
+      companyId: company.company_id,
+      status: "completed",
+      signalCount: result.signalCount,
+      reportId: result.reportId,
+    };
+  }
+
+  const errorMessage =
+    failedRuns
+      .map((run) => readAgentErrorMessage(run.error))
+      .filter(Boolean)
+      .slice(0, 3)
+      .join(" | ") || "All TinyFish agent runs failed";
+
+  await markCompanyRunState(companyRunId, {
+    status: "failed",
+    signal_count: 0,
+    report_id: null,
+    error: errorMessage,
+    completed_at: new Date().toISOString(),
+  });
+
+  return {
+    companyRunId,
+    companyId: company.company_id,
+    status: "failed",
+    signalCount: 0,
+    error: errorMessage,
+  };
 }

--- a/src/services/report-service.ts
+++ b/src/services/report-service.ts
@@ -10,6 +10,14 @@ import {
   SignalDefinition,
 } from "@/lib/types";
 
+export interface DigestCompanyOutcomeInput {
+  companyId: string;
+  reportId?: string | null;
+  status: "completed" | "failed";
+  signalCount: number;
+  error?: string | null;
+}
+
 /** Sort signals by detected_at descending (latest first) */
 function sortByDateDesc(items: ReportSignal[]): ReportSignal[] {
   return items.sort(
@@ -287,8 +295,93 @@ export async function getDigestCompaniesForReports(
       return {
         company,
         findings,
+        status: "changed" as const,
+        reportId: report.report_id,
       };
     });
+}
+
+export async function getDigestCompaniesForOutcomes(
+  outcomes: DigestCompanyOutcomeInput[],
+): Promise<DigestCompany[]> {
+  if (outcomes.length === 0) return [];
+
+  const companyIds = [...new Set(outcomes.map((outcome) => outcome.companyId))];
+  const reportIds = [
+    ...new Set(
+      outcomes
+        .map((outcome) => outcome.reportId)
+        .filter((reportId): reportId is string => !!reportId),
+    ),
+  ];
+
+  const supabase = createAdminClient();
+  const [companyResponse, reportResponse] = await Promise.all([
+    supabase.from("companies").select("*").in("company_id", companyIds),
+    reportIds.length > 0
+      ? supabase.from("reports").select("*, companies(*)").in("report_id", reportIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (companyResponse.error) {
+    throw new Error(`Failed to load digest companies: ${companyResponse.error.message}`);
+  }
+
+  if (reportResponse.error) {
+    throw new Error(`Failed to load digest reports: ${reportResponse.error.message}`);
+  }
+
+  const companyById = new Map(
+    ((companyResponse.data ?? []) as Company[]).map((company) => [
+      company.company_id,
+      company,
+    ]),
+  );
+
+  const reportById = new Map(
+    ((reportResponse.data ?? []) as Array<Record<string, unknown>>).map((row) => {
+      const report = rowToReport(row);
+      return [report.report_id, report] as const;
+    }),
+  );
+
+  return outcomes.flatMap((outcome) => {
+    const company = companyById.get(outcome.companyId);
+    if (!company) return [];
+
+    const report =
+      outcome.reportId && reportById.has(outcome.reportId)
+        ? reportById.get(outcome.reportId)!
+        : null;
+
+    const findings: SignalFinding[] = report
+      ? report.report_data.sections.flatMap((section) =>
+          section.items.map((item) => ({
+            signal_type: section.signal_type,
+            title: item.title,
+            summary: item.summary,
+            source: item.source,
+            url: item.url,
+            detected_at: item.detected_at,
+          })),
+        )
+      : [];
+
+    return [
+      {
+        company,
+        findings,
+        status:
+          outcome.status === "failed"
+            ? ("failed" as const)
+            : outcome.reportId && outcome.signalCount > 0
+              ? ("changed" as const)
+              : ("no_change" as const),
+        reportId: outcome.reportId ?? undefined,
+        error: outcome.error ?? undefined,
+      },
+    ];
+  });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/services/tinyfish-client.ts
+++ b/src/services/tinyfish-client.ts
@@ -1,4 +1,4 @@
-import { TinyFish } from "@tiny-fish/sdk";
+import { TinyFish, RunStatus } from "@tiny-fish/sdk";
 
 const AGENT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -27,12 +27,42 @@ export interface TinyfishSyncResponse {
   error: { code: string; message: string; category: string } | null;
 }
 
+export type TinyfishAsyncRunStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export interface TinyfishAsyncResponse {
+  run_id: string | null;
+  status: TinyfishAsyncRunStatus;
+  result: unknown;
+  error: { code: string; message: string; category: string } | null;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
 function getClient(): TinyFish {
   return new TinyFish(); // reads TINYFISH_API_KEY from env
+}
+
+function mapRunStatus(status: RunStatus): TinyfishAsyncRunStatus {
+  switch (status) {
+    case RunStatus.PENDING:
+      return "queued";
+    case RunStatus.RUNNING:
+      return "running";
+    case RunStatus.COMPLETED:
+      return "completed";
+    case RunStatus.CANCELLED:
+      return "canceled";
+    case RunStatus.FAILED:
+    default:
+      return "failed";
+  }
 }
 
 /** Parse JSON if the value is a string, otherwise return as-is. */
@@ -66,7 +96,7 @@ export function startTinyfishAgent(
   const timeout = setTimeout(() => {
     if (!completedNormally) {
       controller.abort();
-      callbacks.onComplete({ signals: [] });
+      callbacks.onError("Agent timed out while waiting for streaming results");
     }
   }, AGENT_TIMEOUT_MS);
 
@@ -204,7 +234,72 @@ export async function runTinyfishAgentSync(
         category: "runtime",
       },
     };
+  } catch (error) {
+    if ((error as Error).name === "AbortError") {
+      return {
+        run_id: "",
+        status: "FAILED",
+        result: null,
+        error: {
+          code: "TIMEOUT",
+          message: "Agent timed out while waiting for streaming results",
+          category: "runtime",
+        },
+      };
+    }
+
+    throw error;
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function queueTinyfishAgent(
+  config: TinyfishRequest,
+): Promise<TinyfishAsyncResponse> {
+  const client = getClient();
+  const response = await client.agent.queue({
+    url: config.url,
+    goal: config.goal,
+  });
+
+  if (response.error) {
+    return {
+      run_id: null,
+      status: "failed",
+      result: null,
+      error: {
+        code: "QUEUE_FAILED",
+        message: response.error.message,
+        category: response.error.category,
+      },
+    };
+  }
+
+  return {
+    run_id: response.run_id,
+    status: "queued",
+    result: null,
+    error: null,
+  };
+}
+
+export async function getTinyfishRun(
+  runId: string,
+): Promise<TinyfishAsyncResponse> {
+  const client = getClient();
+  const run = await client.runs.get(runId);
+
+  return {
+    run_id: run.run_id,
+    status: mapRunStatus(run.status),
+    result: tryParseJson(run.result),
+    error: run.error
+      ? {
+          code: "RUN_FAILED",
+          message: run.error.message,
+          category: run.error.category,
+        }
+      : null,
+  };
 }

--- a/supabase/migrations/20260330130000_add_pipeline_deliveries.sql
+++ b/supabase/migrations/20260330130000_add_pipeline_deliveries.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Add email delivery tracking and guarantee exactly-once delivery per request
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.pipeline_request_deliveries (
+  delivery_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id uuid NOT NULL REFERENCES public.pipeline_requests(request_id) ON DELETE CASCADE,
+  recipient_email text NOT NULL,
+  sent_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  UNIQUE (request_id, recipient_email)
+);
+
+CREATE INDEX IF NOT EXISTS pipeline_request_deliveries_request_idx
+ON public.pipeline_request_deliveries (request_id);
+
+ALTER TABLE public.pipeline_request_deliveries ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.pipeline_request_deliveries FROM anon, authenticated;
+GRANT ALL ON TABLE public.pipeline_request_deliveries TO service_role;

--- a/supabase/migrations/20260330131000_add_company_agent_runs.sql
+++ b/supabase/migrations/20260330131000_add_company_agent_runs.sql
@@ -1,0 +1,29 @@
+-- =============================================================================
+-- Track individual agent runs explicitly for async polling (Phase 2)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.company_agent_runs (
+  agent_run_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_run_id uuid NOT NULL REFERENCES public.company_pipeline_runs(company_run_id) ON DELETE CASCADE,
+  company_id uuid NOT NULL REFERENCES public.companies(company_id) ON DELETE CASCADE,
+  agent_name text NOT NULL,
+  definition_id uuid,
+  tinyfish_run_id text,
+  status text NOT NULL DEFAULT 'queued' CHECK (
+    status IN ('queued', 'running', 'completed', 'failed', 'canceled')
+  ),
+  attempt integer NOT NULL DEFAULT 1,
+  findings jsonb,
+  error jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  UNIQUE (company_run_id, agent_name)
+);
+
+CREATE INDEX IF NOT EXISTS company_agent_runs_company_run_idx
+ON public.company_agent_runs (company_run_id);
+
+ALTER TABLE public.company_agent_runs ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.company_agent_runs FROM anon, authenticated;
+GRANT ALL ON TABLE public.company_agent_runs TO service_role;

--- a/supabase/migrations/20260330143000_revert_async_pipeline_tables.sql
+++ b/supabase/migrations/20260330143000_revert_async_pipeline_tables.sql
@@ -1,0 +1,6 @@
+-- =============================================================================
+-- Rollback migration: revert async pipeline schema changes
+-- =============================================================================
+
+DROP TABLE IF EXISTS public.company_agent_runs;
+DROP TABLE IF EXISTS public.pipeline_request_deliveries;

--- a/supabase/migrations/20260330150000_add_pipeline_request_key.sql
+++ b/supabase/migrations/20260330150000_add_pipeline_request_key.sql
@@ -1,0 +1,10 @@
+-- =============================================================================
+-- Add explicit request idempotency keys for manual and cron pipeline batches
+-- =============================================================================
+
+ALTER TABLE public.pipeline_requests
+  ADD COLUMN IF NOT EXISTS request_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pipeline_requests_request_key_idx
+ON public.pipeline_requests (request_key)
+WHERE request_key IS NOT NULL;

--- a/supabase/migrations/20260330151000_reintroduce_pipeline_request_deliveries.sql
+++ b/supabase/migrations/20260330151000_reintroduce_pipeline_request_deliveries.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Reintroduce request-scoped digest delivery tracking after rollback cleanup
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.pipeline_request_deliveries (
+  delivery_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id uuid NOT NULL REFERENCES public.pipeline_requests(request_id) ON DELETE CASCADE,
+  recipient_email text NOT NULL,
+  sent_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  UNIQUE (request_id, recipient_email)
+);
+
+CREATE INDEX IF NOT EXISTS pipeline_request_deliveries_request_idx
+ON public.pipeline_request_deliveries (request_id);
+
+ALTER TABLE public.pipeline_request_deliveries ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.pipeline_request_deliveries FROM anon, authenticated;
+GRANT ALL ON TABLE public.pipeline_request_deliveries TO service_role;

--- a/supabase/migrations/20260330152000_reintroduce_company_agent_runs.sql
+++ b/supabase/migrations/20260330152000_reintroduce_company_agent_runs.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- Reintroduce async TinyFish agent run tracking after rollback cleanup
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.company_agent_runs (
+  agent_run_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_run_id uuid NOT NULL REFERENCES public.company_pipeline_runs(company_run_id) ON DELETE CASCADE,
+  company_id uuid NOT NULL REFERENCES public.companies(company_id) ON DELETE CASCADE,
+  agent_name text NOT NULL,
+  definition_id uuid REFERENCES public.signal_definitions(id) ON DELETE SET NULL,
+  tinyfish_run_id text,
+  status text NOT NULL DEFAULT 'queued' CHECK (
+    status IN ('queued', 'running', 'completed', 'failed', 'canceled')
+  ),
+  findings jsonb,
+  error jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  started_at timestamptz,
+  completed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  UNIQUE (company_run_id, agent_name)
+);
+
+CREATE INDEX IF NOT EXISTS company_agent_runs_company_run_idx
+ON public.company_agent_runs (company_run_id);
+
+CREATE INDEX IF NOT EXISTS company_agent_runs_company_status_idx
+ON public.company_agent_runs (company_id, status, created_at DESC);
+
+ALTER TABLE public.company_agent_runs ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.company_agent_runs FROM anon, authenticated;
+GRANT ALL ON TABLE public.company_agent_runs TO service_role;


### PR DESCRIPTION
## Summary
- rebuild the pipeline around request-scoped email delivery and previewable request state
- move company processing onto async TinyFish queue/poll/finalize flow instead of long-lived stream workers
- add request idempotency, request preview APIs, and exactly-once delivery tracking
- improve mobile companies UI and surface competitor tracking-limit errors honestly

## What changed
- added `GET /api/pipeline-requests/[id]` and `GET /api/pipeline-requests/[id]?preview=true`
- updated `POST /api/trigger-pipeline` to return request metadata and support request keys end to end
- introduced request-scoped delivery persistence via `pipeline_request_deliveries`
- introduced async agent persistence via `company_agent_runs`
- rebuilt finalization to send one digest per request/recipient from request outcomes
- escaped failed-company error strings in digest HTML
- added a mobile card layout for `/companies` and kept the dense table desktop-only
- return a real 400 for competitor tracking-limit errors instead of a misleading 500

## Verification
- `npx tsc --noEmit`
- `npm run build`
- remote Supabase schema aligned on the correct project and rebuilt tables verified present
- manual one-company request verified on the correct app/tunnel with preview + sent delivery row
- manual multi-company request verified with one combined digest preview + sent delivery row
- cron-style request verified with preview + sent delivery row
- duplicate `request_key` idempotency verified on manual request flow
- deterministic failed-digest rendering verified with escaped error content
- targeted TinyFish UI pass on the correct app/tunnel for core authenticated surfaces

## Notes
- raw overnight evidence is local under `.sisyphus/evidence/` and was intentionally not committed
- TinyFish still reported some low-confidence UI findings around competitor add limits and icons/assets; these were investigated and are not considered PR blockers for this branch
- after the main verification runs, the test account delivery email was reset back to `pentalaacenha@gmail.com` with daily frequency for subsequent runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline request preview and email digest preview capabilities.
  * Implemented request key-based idempotency for pipeline runs.
  * Upgraded pipeline execution to a multi-step agent-based workflow with polling.
  * Added mobile navigation improvements with sidebar toggle and responsive layouts.

* **Bug Fixes**
  * Enhanced error handling for competitor tracking with specific error messages.
  * Improved stale company run recovery and reattachment.

* **Improvements**
  * Enhanced email digest display with status indicators (changed, no_change, failed).
  * Made digest email delivery tracking idempotent per request and recipient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->