### PR TITLE
fix: remove tracking limits and deduplicate competitor search

### DIFF
--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -57,7 +57,6 @@ export default function CompaniesPage() {
   const { currentOrg, user } = useAuth();
 
   const [companies, setCompanies] = useState<TrackedCompany[]>([]);
-  const [trackingLimit, setTrackingLimit] = useState(5);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCompanyIds, setSelectedCompanyIds] = useState<string[]>([]);
@@ -85,9 +84,8 @@ export default function CompaniesPage() {
 
   const fetchCompanies = useCallback(async () => {
     try {
-      const { companies: data, tracking_limit } = await getCompanies();
+      const { companies: data } = await getCompanies();
       setCompanies(data);
-      setTrackingLimit(tracking_limit);
     } catch {
       setCompanies([]);
     }
@@ -351,7 +349,7 @@ export default function CompaniesPage() {
         <div>
           <h1 className="text-xl font-semibold">Tracked Companies</h1>
           <p className="text-sm text-muted-foreground">
-            {companies.length}/{trackingLimit} companies tracked
+            {companies.length} companies tracked
           </p>
         </div>
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -250,10 +250,10 @@ export async function searchCatalog(
   return res.json();
 }
 
-export async function getCompanies(): Promise<{ companies: TrackedCompany[]; tracking_limit: number }> {
+export async function getCompanies(): Promise<{ companies: TrackedCompany[] }> {
   const res = await authFetch(`${API_BASE}/companies`);
   const data = await res.json();
-  return { companies: data.companies ?? [], tracking_limit: data.tracking_limit ?? 5 };
+  return { companies: data.companies ?? [] };
 }
 
 export async function untrackCompany(id: string): Promise<void> {

--- a/src/services/company-service.ts
+++ b/src/services/company-service.ts
@@ -109,9 +109,21 @@ export async function searchCompanyCatalog(
   );
   const ranked = rankCompaniesBySearch(candidates, query);
 
+  // Exclude ghost entries (no domain) and deduplicate by domain
+  const seen = new Map<string, Company>();
+  const deduped: Company[] = [];
+  for (const company of ranked) {
+    if (!company.domain) continue;
+    const key = company.domain.toLowerCase();
+    if (!seen.has(key)) {
+      seen.set(key, company);
+      deduped.push(company);
+    }
+  }
+
   return {
-    companies: ranked.slice(offset, offset + limit),
-    total: query?.trim().length ? ranked.length : count ?? ranked.length,
+    companies: deduped.slice(offset, offset + limit),
+    total: query?.trim().length ? deduped.length : count ?? deduped.length,
   };
 }
 
@@ -168,24 +180,6 @@ export async function trackCompany(
 
   if ((existingCount ?? 0) > 0) {
     return;
-  }
-
-  // Check tracking limit
-  const { data: org } = await supabase
-    .from("organizations")
-    .select("tracking_limit")
-    .eq("organization_id", organizationId)
-    .single();
-
-  const limit = org?.tracking_limit ?? 5;
-
-  const { count } = await supabase
-    .from("organization_tracked_companies")
-    .select("id", { count: "exact", head: true })
-    .eq("organization_id", organizationId);
-
-  if ((count ?? 0) >= limit) {
-    throw new Error(`Tracking limit reached (${limit}). Untrack a company first.`);
   }
 
   const { error } = await supabase


### PR DESCRIPTION
## Summary
- Removes the hardcoded 5-company tracking limit that was blocking Kelvin from tracking 29+ startups
- Fixes duplicate competitor search results (ghost company entries with no domain no longer appear)
- Removes "X/5 companies tracked" display from companies page — now just shows count

## Changes
- `company-service.ts`: Remove tracking limit check in `trackCompany()`, add domain dedup + ghost filtering in `searchCompanyCatalog()`
- `organization-service.ts`: No changes (function kept for API compat)
- `client.ts`: Remove `tracking_limit` from `getCompanies()` return type
- `companies/page.tsx`: Remove `trackingLimit` state and limit display

## Test plan
- [ ] Track more than 5 companies — should succeed without error
- [ ] Search for "Stripe" as competitor — should show only one result with domain
- [ ] Companies page shows "X companies tracked" without limit denominator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Company tracking no longer has a limit—track as many companies as needed.

* **Bug Fixes**
  * Search results are deduplicated to eliminate duplicate entries.
  * Company tracking display simplified to show total tracked count only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->