### PR TITLE
feat: signal quality pipeline — scoring, freshness, dedup improvements

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -196,6 +196,9 @@ export interface SignalFinding {
   url?: string;
   detected_at?: string;
   signal_definition_id?: string;
+  priority_score?: number;
+  priority_tier?: "high" | "medium" | "low";
+  freshness_class?: "fresh" | "aging" | "stale";
 }
 
 // ---------- Signal Definitions ----------

--- a/src/services/pipeline-service.ts
+++ b/src/services/pipeline-service.ts
@@ -22,10 +22,15 @@ import {
 } from "@/services/report-service";
 import { getSignalDefinitions } from "@/services/signal-definition-service";
 import { getTinyfishRun, queueTinyfishAgent } from "@/services/tinyfish-client";
+import { scoreSignalFinding, classifyFreshness } from "@/services/signal-scoring";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(/[^\w\s]/g, "").replace(/\s+/g, " ").trim();
+}
 
 function sanitizeTimestamp(value: string | undefined): string | null {
   if (!value) return null;
@@ -54,6 +59,7 @@ async function deduplicateFindings(
   const supabase = createAdminClient();
   const newFindings: SignalFinding[] = [];
   const batchTitles = new Set<string>();
+  const batchNormalized = new Set<string>();
 
   for (const finding of findings) {
     const titleLower = (finding.title ?? "").trim().toLowerCase();
@@ -89,6 +95,16 @@ async function deduplicateFindings(
       continue;
     }
 
+    // Layer 1c: Normalized title match within batch (strip punctuation, collapse whitespace)
+    const normalized = normalizeTitle(finding.title ?? "");
+    if (normalized.length > 0 && batchNormalized.has(normalized)) {
+      console.log(
+        "[DEDUP] DUPLICATE — title: \"%s\" | reason: normalized title match in batch",
+        finding.title,
+      );
+      continue;
+    }
+
     // Layer 2: Deep URL match
     if (finding.url) {
       let pathDepth = 0;
@@ -119,6 +135,7 @@ async function deduplicateFindings(
     );
     newFindings.push(finding);
     batchTitles.add(titleLower);
+    if (normalized.length > 0) batchNormalized.add(normalized);
   }
 
   return newFindings;
@@ -155,7 +172,7 @@ async function llmDedup(
       .eq("company_id", companyId)
       .eq("signal_type", signalType)
       .order("created_at", { ascending: false })
-      .limit(10);
+      .limit(50);
     existingByType.set(signalType, data ?? []);
   }
 
@@ -282,6 +299,8 @@ async function storeSignals(
     content: finding.summary,
     url: finding.url || null,
     detected_at: sanitizeTimestamp(finding.detected_at),
+    priority_score: finding.priority_score ?? null,
+    priority_tier: finding.priority_tier ?? null,
   }));
 
   const { error } = await supabase.from("signals").insert(rows);
@@ -323,26 +342,53 @@ export async function processCompany(
     const finalFindings = await llmDedup(company.company_id, newFindings);
     console.log("%s After LLM dedup: %d signals (filtered %d more)", tag, finalFindings.length, newFindings.length - finalFindings.length);
 
-    // 5. Store final findings in DB
+    // 5. Score and classify each finding (#23, #19)
+    for (const f of finalFindings) {
+      const { score, tier } = scoreSignalFinding(f);
+      f.priority_score = score;
+      f.priority_tier = tier;
+      f.freshness_class = classifyFreshness(f.detected_at);
+    }
+
+    // 6. Store & report
     if (finalFindings.length > 0) {
+      // Store ALL signals for history (#22)
       await storeSignals(company.company_id, finalFindings);
       console.log("%s Stored %d signals", tag, finalFindings.length);
 
-      // 6. Generate & store report
-      const reportData = generateReportFromFindings(company, finalFindings, definitions);
-      const report = await storeReport(company.company_id, reportData, trigger);
-      console.log("%s Report stored (%d sections)", tag, reportData.sections.length);
+      // Only digest-worthy signals enter the report (#22, #20)
+      const digestFindings = finalFindings.filter(
+        (f) => f.priority_tier !== "low" && f.freshness_class !== "stale",
+      );
 
+      if (digestFindings.length > 0) {
+        const reportData = generateReportFromFindings(company, digestFindings, definitions);
+        const report = await storeReport(company.company_id, reportData, trigger);
+        console.log("%s Report stored (%d sections, %d digest signals)", tag, reportData.sections.length, digestFindings.length);
+
+        await updateLastAgentRun(company.company_id);
+
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        console.log("%s Done in %ss — %d new signals (%d digest-worthy)", tag, elapsed, finalFindings.length, digestFindings.length);
+
+        return {
+          companyId: company.company_id,
+          companyName: company.company_name,
+          signalCount: finalFindings.length,
+          reportId: report.report_id,
+          findings: finalFindings,
+        };
+      }
+
+      // Signals stored but none digest-worthy
       await updateLastAgentRun(company.company_id);
-
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-      console.log("%s Done in %ss — %d new signals", tag, elapsed, finalFindings.length);
+      console.log("%s Done in %ss — %d signals stored (none digest-worthy)", tag, elapsed, finalFindings.length);
 
       return {
         companyId: company.company_id,
         companyName: company.company_name,
         signalCount: finalFindings.length,
-        reportId: report.report_id,
         findings: finalFindings,
       };
     }
@@ -638,22 +684,48 @@ async function persistCompanyFindings(
     newFindings.length - finalFindings.length,
   );
 
+  // Score and classify each finding (#23, #19)
+  for (const f of finalFindings) {
+    const { score, tier } = scoreSignalFinding(f);
+    f.priority_score = score;
+    f.priority_tier = tier;
+    f.freshness_class = classifyFreshness(f.detected_at);
+  }
+
   if (finalFindings.length > 0) {
+    // Store ALL signals for history (#22)
     await storeSignals(company.company_id, finalFindings);
     console.log("%s Stored %d signals", tag, finalFindings.length);
 
-    const reportData = generateReportFromFindings(company, finalFindings, definitions);
-    const report = await storeReport(company.company_id, reportData, trigger);
-    console.log("%s Report stored (%d sections)", tag, reportData.sections.length);
+    // Only digest-worthy signals enter the report (#22, #20)
+    const digestFindings = finalFindings.filter(
+      (f) => f.priority_tier !== "low" && f.freshness_class !== "stale",
+    );
+    console.log("%s Digest-worthy: %d (filtered %d low/stale)", tag, digestFindings.length, finalFindings.length - digestFindings.length);
 
+    if (digestFindings.length > 0) {
+      const reportData = generateReportFromFindings(company, digestFindings, definitions);
+      const report = await storeReport(company.company_id, reportData, trigger);
+      console.log("%s Report stored (%d sections)", tag, reportData.sections.length);
+
+      await updateLastAgentRun(company.company_id);
+
+      return {
+        companyId: company.company_id,
+        companyName: company.company_name,
+        signalCount: digestFindings.length,
+        reportId: report.report_id,
+        findings: digestFindings,
+      };
+    }
+
+    // Signals stored but none were digest-worthy
     await updateLastAgentRun(company.company_id);
-
     return {
       companyId: company.company_id,
       companyName: company.company_name,
-      signalCount: finalFindings.length,
-      reportId: report.report_id,
-      findings: finalFindings,
+      signalCount: 0,
+      findings: [],
     };
   }
 

--- a/src/services/signal-scoring.ts
+++ b/src/services/signal-scoring.ts
@@ -1,4 +1,4 @@
-import type { Signal } from "@/lib/types";
+import type { Signal, SignalFinding } from "@/lib/types";
 
 const SIGNAL_TYPE_WEIGHTS: Record<string, number> = {
   financing: 30,
@@ -92,4 +92,47 @@ export function enrichSignalsWithPriority<T extends Signal>(signals: T[]): T[] {
       priority_tier: tier,
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Freshness classification (#19)
+// ---------------------------------------------------------------------------
+
+export type FreshnessClass = "fresh" | "aging" | "stale";
+
+export function classifyFreshness(
+  detectedAt?: string,
+  createdAt?: string,
+): FreshnessClass {
+  const ref = detectedAt ?? createdAt;
+  if (!ref) return "aging";
+
+  const ageMs = Date.now() - new Date(ref).getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+
+  if (ageDays <= 7) return "fresh";
+  if (ageDays <= 30) return "aging";
+  return "stale";
+}
+
+// ---------------------------------------------------------------------------
+// Score a SignalFinding (pre-DB type) by adapting to Signal shape (#23)
+// ---------------------------------------------------------------------------
+
+export function scoreSignalFinding(finding: SignalFinding): {
+  score: number;
+  tier: "high" | "medium" | "low";
+} {
+  const adapted: Signal = {
+    signal_id: "",
+    company_id: "",
+    signal_type: finding.signal_type,
+    source: finding.source ?? "",
+    title: finding.title ?? "",
+    content: finding.summary ?? "",
+    url: finding.url ?? null,
+    detected_at: finding.detected_at ?? null,
+    created_at: new Date().toISOString(),
+  };
+  return scoreSignal(adapted);
 }


### PR DESCRIPTION
## Summary
- **Signal scoring wired into pipeline write path** — `scoreSignalFinding()` adapter maps `SignalFinding` → `Signal` fields and scores every finding before DB insert (#23)
- **Freshness classification** — `classifyFreshness()` tags findings as fresh/aging/stale based on `detected_at` age (#19)
- **Digest-worthy filtering** — stores ALL signals for history but only passes non-low, non-stale findings to report generation (#22, #20)
- **Improved dedup** — normalized-title layer (strip punctuation, collapse whitespace) catches near-dupes; LLM window widened 10→50 (#21)
- **DB persistence** — `priority_score` and `priority_tier` written to signals table on insert

## Test plan
- [ ] Trigger pipeline for a tracked company → verify signals get `priority_score`/`priority_tier` in DB
- [ ] Confirm low-priority and stale signals are stored but excluded from reports
- [ ] Verify near-duplicate signals (same title with different punctuation) are deduped
- [ ] Check that digest email only contains high/medium + fresh/aging signals
- [ ] Run `npx tsc --noEmit` — passes clean

Closes #19, #20, #21, #22, #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Signals are now classified by freshness status (fresh, aging, stale) and priority tier (high, medium, low).
  * Reports automatically filter to display only high and medium priority, non-stale signals, improving relevance and reducing noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->