### PR TITLE
fix: bucket name display and per-group search

### DIFF
--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -59,7 +59,6 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 
 const SKELETON_ROWS = ["row-a", "row-b", "row-c"];


### PR DESCRIPTION
## Summary
- **Bug fix:** Bucket column now shows the bucket name (e.g. "payments") instead of the raw UUID. Uses `company.bucket?.name` directly instead of relying on Select child-matching which could flash the UUID during render races.
- **New feature:** Adds a search input within each bucket group section (shown when group has >5 companies). Type to filter companies within that group by name/domain without scrolling.

Closes #42, closes #43

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Assign a company to a bucket → bucket column shows name, not UUID
- [ ] With 29 companies in Unassigned, search input appears
- [ ] Type a company name → list filters within that group only
- [ ] Clear search → all companies in group are shown
- [ ] Groups with ≤5 companies don't show the search input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled independent search functionality for companies within each bucket, displayed when a bucket contains more than 5 companies.
  * Improved company labeling to display assigned bucket names throughout the interface.
  * Enhanced search feedback with refined result counts and contextual empty-state messaging for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->