### PR TITLE
feat: default to search/fetch pipeline and add benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.7",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5"
       }
     },
@@ -855,6 +856,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7437,6 +7880,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -8323,6 +8808,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -13853,6 +14353,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "qa:tinyfish": "node scripts/run-tinyfish-qa.mjs"
+    "qa:tinyfish": "node scripts/run-tinyfish-qa.mjs",
+    "bench:pipeline-modes": "tsx scripts/benchmark-pipeline-modes.ts",
+    "share:tinyfi": "sh ./scripts/share-via-tinyfi.sh"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.63",
@@ -54,6 +56,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.7",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5"
   }
 }

--- a/scripts/benchmark-pipeline-modes.ts
+++ b/scripts/benchmark-pipeline-modes.ts
@@ -1,0 +1,603 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Side-by-side injected signal benchmark for Daily Delta.
+ *
+ * This compares:
+ *   1. TinyFish browser-agent extraction
+ *   2. search + fetch + Claude extraction
+ *
+ * Both modes are pointed at the same public fixture URL exposed from localhost
+ * through tinyfi.sh, so the comparison is deterministic.
+ *
+ * Example:
+ *   npm run dev
+ *   npm run share:tinyfi
+ *   TINYFISH_API_KEY=... ANTHROPIC_API_KEY=... \
+ *   NEXT_PUBLIC_SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *   npm run bench:pipeline-modes -- \
+ *     --public-base-url https://your-subdomain.tinyfi.sh \
+ *     --company-id <uuid>
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import {
+  benchmarkCompanyWithLegacyAgents,
+  benchmarkCompanyWithSearchFetchExtract,
+} from "../src/services/pipeline-service";
+import { createAdminClient } from "../src/lib/supabase/admin";
+import { classifyFreshness } from "../src/services/signal-scoring";
+import { getCompaniesByIds, getTrackedActiveCompanies } from "../src/services/company-service";
+import type { Company, CompanyPipelineResult, SignalDefinition } from "../src/lib/types";
+
+type BenchmarkMode = "legacy_tinyfish_agents" | "search_fetch_extract";
+
+interface Args {
+  publicBaseUrl: string;
+  companyIds: string[];
+  allActive: boolean;
+  limit?: number;
+  concurrency: number;
+  modes: BenchmarkMode[];
+  keepData: boolean;
+  outputPath?: string;
+}
+
+interface StoredSignalRow {
+  signal_id: string;
+  company_id: string;
+  signal_type: string;
+  source: string;
+  title: string;
+  content: string;
+  url: string | null;
+  detected_at: string | null;
+  created_at: string;
+  priority_score: number | null;
+  priority_tier: "high" | "medium" | "low" | null;
+}
+
+interface ModeRunResult {
+  mode: BenchmarkMode;
+  companyId: string;
+  companyName: string;
+  benchmarkToken: string;
+  fixtureUrl: string;
+  durationMs: number;
+  pipeline: CompanyPipelineResult;
+  storedSignals: Array<
+    StoredSignalRow & {
+      freshness: ReturnType<typeof classifyFreshness>;
+    }
+  >;
+  reportId?: string;
+  reportContainsToken: boolean;
+  canaryCaptured: boolean;
+}
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  npm run bench:pipeline-modes -- --public-base-url <https://...tinyfi.sh> [options]",
+    "",
+    "Options:",
+    "  --company-id <uuid>         Benchmark one company (repeatable)",
+    "  --all-active                Benchmark all active tracked companies",
+    "  --limit <n>                 Limit the all-active company set",
+    "  --concurrency <n>           Run up to n companies in parallel per mode (default: 1)",
+    "  --mode <legacy|fetch|both>  Default: both",
+    "  --keep-data                 Keep benchmark-created rows instead of cleaning up",
+    "  --output <path>             Write markdown summary to a custom file",
+    "  --help                      Show this help text",
+  ].join("\n");
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    publicBaseUrl: process.env.TINYFISH_BENCH_BASE_URL ?? "",
+    companyIds: [],
+    allActive: false,
+    concurrency: 1,
+    modes: ["legacy_tinyfish_agents", "search_fetch_extract"],
+    keepData: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--public-base-url":
+        args.publicBaseUrl = argv[++i] ?? "";
+        break;
+      case "--company-id":
+        args.companyIds.push(argv[++i] ?? "");
+        break;
+      case "--all-active":
+        args.allActive = true;
+        break;
+      case "--limit":
+        args.limit = Number(argv[++i] ?? "");
+        break;
+      case "--concurrency":
+        args.concurrency = Number(argv[++i] ?? "");
+        break;
+      case "--mode": {
+        const value = (argv[++i] ?? "both").toLowerCase();
+        if (value === "legacy") args.modes = ["legacy_tinyfish_agents"];
+        else if (value === "fetch") args.modes = ["search_fetch_extract"];
+        else args.modes = ["legacy_tinyfish_agents", "search_fetch_extract"];
+        break;
+      }
+      case "--keep-data":
+        args.keepData = true;
+        break;
+      case "--output":
+        args.outputPath = argv[++i] ?? "";
+        break;
+      case "--help":
+        console.log(usage());
+        process.exit(0);
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+  }
+
+  if (!args.publicBaseUrl) {
+    throw new Error(
+      "Missing --public-base-url (or TINYFISH_BENCH_BASE_URL). Run `npx tinyfi.sh http 3000` and pass the public URL here.",
+    );
+  }
+
+  if (!args.allActive && args.companyIds.length === 0) {
+    throw new Error("Pass at least one --company-id or use --all-active.");
+  }
+  if (!Number.isFinite(args.concurrency) || args.concurrency < 1) {
+    throw new Error("--concurrency must be a positive integer.");
+  }
+  args.concurrency = Math.max(1, Math.floor(args.concurrency));
+
+  return args;
+}
+
+function assertRequiredEnv(modes: BenchmarkMode[]): void {
+  const required = new Set([
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ]);
+  if (modes.includes("legacy_tinyfish_agents")) {
+    required.add("TINYFISH_API_KEY");
+  }
+  if (modes.includes("search_fetch_extract")) {
+    required.add("ANTHROPIC_API_KEY");
+  }
+
+  const missing = [...required].filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(", ")}`);
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+async function resolveCompanies(args: Args): Promise<Company[]> {
+  if (args.allActive) {
+    const companies = await getTrackedActiveCompanies();
+    return typeof args.limit === "number" && args.limit > 0
+      ? companies.slice(0, args.limit)
+      : companies;
+  }
+
+  const companyIds = [...new Set(args.companyIds.filter(Boolean))];
+  const companies = await getCompaniesByIds(companyIds);
+  if (companies.length !== companyIds.length) {
+    const foundIds = new Set(companies.map((company) => company.company_id));
+    const missing = companyIds.filter((companyId) => !foundIds.has(companyId));
+    throw new Error(`Could not find companies: ${missing.join(", ")}`);
+  }
+  return companies;
+}
+
+function buildFixtureUrl(publicBaseUrl: string, company: Company, token: string): string {
+  const url = new URL("/api/benchmark-fixtures/high-signal", normalizeBaseUrl(publicBaseUrl));
+  url.searchParams.set("company", company.company_name);
+  url.searchParams.set("token", token);
+  url.searchParams.set("source", "TechCrunch");
+  url.searchParams.set("date", new Date().toISOString().slice(0, 10));
+  url.searchParams.set("amount", "$250 million");
+  url.searchParams.set("round", "Series F");
+  return url.toString();
+}
+
+function buildBenchmarkInstructions(companyName: string, token: string): string {
+  return [
+    `Read this page and extract exactly one fundraising signal for ${companyName}.`,
+    `Use the exact article headline as the title, including the benchmark token [${token}].`,
+    `Set signal_type to fundraising_signal.`,
+    `Set source to the publication name shown on the page.`,
+    `Set url to the page URL.`,
+    `Set detected_at to the published date visible on the page.`,
+    `Return {"signals": []} if the page does not clearly describe a fundraising event for ${companyName}.`,
+  ].join(" ");
+}
+
+async function createBenchmarkDefinition(
+  companyId: string,
+  fixtureUrl: string,
+  token: string,
+  companyName: string,
+): Promise<SignalDefinition> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("signal_definitions")
+    .insert({
+      company_id: companyId,
+      is_default: false,
+      created_by: null,
+      name: `Benchmark Fundraising Signal ${token}`,
+      signal_type: "fundraising_signal",
+      display_name: `Benchmark Fundraising Signal ${token}`,
+      target_url: fixtureUrl,
+      search_instructions: buildBenchmarkInstructions(companyName, token),
+      scope: "company",
+      enabled: true,
+      sort_order: 9999,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create benchmark signal definition: ${error.message}`);
+  }
+
+  return data as SignalDefinition;
+}
+
+async function findBenchmarkSignals(
+  companyId: string,
+  token: string,
+  startedAtIso: string,
+): Promise<
+  Array<
+    StoredSignalRow & {
+      freshness: ReturnType<typeof classifyFreshness>;
+    }
+  >
+> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("signals")
+    .select("*")
+    .eq("company_id", companyId)
+    .gte("created_at", startedAtIso)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load benchmark signals: ${error.message}`);
+  }
+
+  return ((data ?? []) as StoredSignalRow[])
+    .filter(
+      (signal) =>
+        signal.title.includes(token) ||
+        signal.content.includes(token) ||
+        (signal.url ?? "").includes(token),
+    )
+    .map((signal) => ({
+      ...signal,
+      freshness: classifyFreshness(signal.detected_at ?? undefined, signal.created_at),
+    }));
+}
+
+async function reportContainsToken(reportId: string | undefined, token: string): Promise<boolean> {
+  if (!reportId) return false;
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("reports")
+    .select("report_data")
+    .eq("report_id", reportId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load benchmark report: ${error.message}`);
+  }
+
+  if (!data) return false;
+  return JSON.stringify((data as { report_data: unknown }).report_data).includes(token);
+}
+
+async function cleanupBenchmarkArtifacts(
+  companyId: string,
+  definitionId: string,
+  token: string,
+  reportId?: string,
+): Promise<void> {
+  const supabase = createAdminClient();
+
+  const { data: signalRows, error: signalLoadError } = await supabase
+    .from("signals")
+    .select("signal_id, title, content, url")
+    .eq("company_id", companyId);
+  if (signalLoadError) {
+    throw new Error(`Failed to load benchmark signals for cleanup: ${signalLoadError.message}`);
+  }
+
+  const signalIds = ((signalRows ?? []) as Array<{
+    signal_id: string;
+    title: string;
+    content: string;
+    url: string | null;
+  }>)
+    .filter(
+      (signal) =>
+        signal.title.includes(token) ||
+        signal.content.includes(token) ||
+        (signal.url ?? "").includes(token),
+    )
+    .map((signal) => signal.signal_id);
+
+  if (reportId) {
+    const { error: reportError } = await supabase
+      .from("reports")
+      .delete()
+      .eq("report_id", reportId);
+    if (reportError) {
+      throw new Error(`Failed to delete benchmark report: ${reportError.message}`);
+    }
+  }
+
+  if (signalIds.length > 0) {
+    const { error: signalError } = await supabase
+      .from("signals")
+      .delete()
+      .in("signal_id", signalIds);
+    if (signalError) {
+      throw new Error(`Failed to delete benchmark signals: ${signalError.message}`);
+    }
+  }
+
+  const { error: definitionError } = await supabase
+    .from("signal_definitions")
+    .delete()
+    .eq("id", definitionId);
+  if (definitionError) {
+    throw new Error(`Failed to delete benchmark definition: ${definitionError.message}`);
+  }
+}
+
+async function runModeForCompany(
+  mode: BenchmarkMode,
+  company: Company,
+  publicBaseUrl: string,
+  keepData: boolean,
+): Promise<ModeRunResult> {
+  const benchmarkToken = `BENCH-${mode === "legacy_tinyfish_agents" ? "LEGACY" : "FETCH"}-${randomUUID().slice(0, 8).toUpperCase()}`;
+  const fixtureUrl = buildFixtureUrl(publicBaseUrl, company, benchmarkToken);
+  const definition = await createBenchmarkDefinition(
+    company.company_id,
+    fixtureUrl,
+    benchmarkToken,
+    company.company_name,
+  );
+
+  const startedAtIso = new Date().toISOString();
+  const start = Date.now();
+
+  let pipeline: CompanyPipelineResult;
+  let reportId: string | undefined;
+  try {
+    pipeline =
+      mode === "legacy_tinyfish_agents"
+        ? await benchmarkCompanyWithLegacyAgents(company, [definition], "manual")
+        : await benchmarkCompanyWithSearchFetchExtract(company, [definition], "manual");
+    reportId = pipeline.reportId;
+
+    const storedSignals = await findBenchmarkSignals(
+      company.company_id,
+      benchmarkToken,
+      startedAtIso,
+    );
+    const containsToken = await reportContainsToken(reportId, benchmarkToken);
+
+    return {
+      mode,
+      companyId: company.company_id,
+      companyName: company.company_name,
+      benchmarkToken,
+      fixtureUrl,
+      durationMs: Date.now() - start,
+      pipeline,
+      storedSignals,
+      reportId,
+      reportContainsToken: containsToken,
+      canaryCaptured:
+        storedSignals.some(
+          (signal) =>
+            signal.signal_type === "fundraising_signal" &&
+            signal.priority_tier === "high" &&
+            signal.freshness === "fresh",
+        ) && containsToken,
+    };
+  } finally {
+    if (!keepData) {
+      try {
+        await cleanupBenchmarkArtifacts(
+          company.company_id,
+          definition.id,
+          benchmarkToken,
+          reportId,
+        );
+      } catch (error) {
+        console.warn(
+          "[BENCH] Cleanup warning for %s/%s: %s",
+          company.company_name,
+          mode,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+  }
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 60_000) return `${(ms / 60_000).toFixed(2)}m`;
+  if (ms >= 1_000) return `${(ms / 1_000).toFixed(2)}s`;
+  return `${ms}ms`;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) return;
+      results[currentIndex] = await worker(items[currentIndex], currentIndex);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
+}
+
+function buildMarkdownReport(
+  args: Args,
+  companies: Company[],
+  results: ModeRunResult[],
+  totalsByMode: Map<BenchmarkMode, number>,
+): string {
+  const lines: string[] = [
+    "# Pipeline Mode Benchmark",
+    "",
+    `Run at: ${new Date().toISOString()}`,
+    `Public fixture base: ${normalizeBaseUrl(args.publicBaseUrl)}`,
+    `Companies: ${companies.length}`,
+    "",
+    "## Mode Summary",
+    "",
+    "| Mode | Companies | Total Runtime | Under 13m | Canary Captured | Failures |",
+    "|------|-----------|---------------|-----------|------------------|----------|",
+  ];
+
+  for (const mode of args.modes) {
+    const modeResults = results.filter((result) => result.mode === mode);
+    const total = totalsByMode.get(mode) ?? 0;
+    const canaryPasses = modeResults.filter((result) => result.canaryCaptured).length;
+    const failures = modeResults.filter((result) => !!result.pipeline.error).length;
+    lines.push(
+      `| ${mode} | ${modeResults.length} | ${formatMs(total)} | ${total <= 13 * 60_000 ? "YES" : "NO"} | ${canaryPasses}/${modeResults.length} | ${failures} |`,
+    );
+  }
+
+  lines.push("", "## Per Company", "", "| Company | Mode | Runtime | Stored Signals | Report | Canary | Notes |", "|---------|------|---------|----------------|--------|--------|-------|");
+  for (const result of results) {
+    const notes = result.pipeline.error
+      ? result.pipeline.error.replace(/\|/g, "/")
+      : result.storedSignals.length > 0
+        ? result.storedSignals
+            .map((signal) => `${signal.title} (${signal.priority_tier ?? "n/a"}, ${signal.freshness})`)
+            .join(" ; ")
+            .replace(/\|/g, "/")
+        : "No benchmark signals stored";
+
+    lines.push(
+      `| ${result.companyName} | ${result.mode} | ${formatMs(result.durationMs)} | ${result.storedSignals.length} | ${result.reportContainsToken ? "YES" : "NO"} | ${result.canaryCaptured ? "PASS" : "FAIL"} | ${notes} |`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  assertRequiredEnv(args.modes);
+
+  const companies = await resolveCompanies(args);
+  if (companies.length === 0) {
+    throw new Error("No companies matched the requested benchmark scope.");
+  }
+
+  const results: ModeRunResult[] = [];
+  const totalsByMode = new Map<BenchmarkMode, number>();
+
+  console.log(
+    "[BENCH] Running %d mode(s) across %d company(s) with concurrency=%d",
+    args.modes.length,
+    companies.length,
+    args.concurrency,
+  );
+
+  for (const mode of args.modes) {
+    const modeStart = Date.now();
+    console.log("[BENCH] Starting mode: %s", mode);
+
+    const modeResults = await mapWithConcurrency(
+      companies,
+      args.concurrency,
+      async (company) => {
+        console.log("[BENCH] %s -> %s", mode, company.company_name);
+        return runModeForCompany(
+          mode,
+          company,
+          args.publicBaseUrl,
+          args.keepData,
+        );
+      },
+    );
+    results.push(...modeResults);
+
+    totalsByMode.set(mode, Date.now() - modeStart);
+  }
+
+  const markdown = buildMarkdownReport(args, companies, results, totalsByMode);
+  const outputPath =
+    args.outputPath ||
+    resolve(
+      process.cwd(),
+      ".context",
+      `pipeline-benchmark-${new Date().toISOString().replace(/[:.]/g, "-")}.md`,
+    );
+  const jsonPath = outputPath.replace(/\.md$/i, ".json");
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, markdown, "utf8");
+  await writeFile(
+    jsonPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        publicBaseUrl: normalizeBaseUrl(args.publicBaseUrl),
+        companies: companies.map((company) => ({
+          companyId: company.company_id,
+          companyName: company.company_name,
+        })),
+        totalsByMode: Object.fromEntries(totalsByMode),
+        results,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  console.log(markdown);
+  console.log("");
+  console.log("[BENCH] Markdown report: %s", outputPath);
+  console.log("[BENCH] JSON report: %s", jsonPath);
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/benchmark-pipeline-real-world.ts
+++ b/scripts/benchmark-pipeline-real-world.ts
@@ -1,0 +1,719 @@
+#!/usr/bin/env npx tsx
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { createAdminClient } from "../src/lib/supabase/admin";
+import type { Company, SignalDefinition } from "../src/lib/types";
+import {
+  getCompaniesByIds,
+  getTrackedActiveCompanies,
+} from "../src/services/company-service";
+import { resolveTemplate } from "../src/lib/utils/template";
+import {
+  analyzeCompanyWithMode,
+  type CompanyPipelineAnalysis,
+} from "../src/services/pipeline-service";
+import { classifyFreshness } from "../src/services/signal-scoring";
+import { getSignalDefinitions } from "../src/services/signal-definition-service";
+
+interface Args {
+  companyIds: string[];
+  freshTarget: number;
+  quietTarget: number;
+  preflightFreshPool: number;
+  preflightQuietPool: number;
+  historyDays: number;
+  concurrency: number;
+  definitionMode: "deterministic" | "all";
+  maxCompanyMs: number;
+  outputPath?: string;
+}
+
+interface HistoryRow {
+  company_id: string;
+  detected_at: string | null;
+  created_at: string;
+  priority_tier: "high" | "medium" | "low" | null;
+}
+
+interface CompanyHistorySummary {
+  recentSignalCount: number;
+  recentDigestCount: number;
+  recentFreshHighCount: number;
+  recentLowOrStaleCount: number;
+  latestSignalAt: string | null;
+}
+
+interface BenchmarkCandidate {
+  company: Company;
+  definitions: SignalDefinition[];
+  history: CompanyHistorySummary;
+}
+
+interface SelectedCompany {
+  company: Company;
+  definitions: SignalDefinition[];
+  history: CompanyHistorySummary;
+  fetchPreflight: CompanyPipelineAnalysis;
+  selectionBucket: "fresh" | "quiet" | "fill";
+}
+
+function timeoutAnalysis(
+  mode: CompanyPipelineAnalysis["mode"],
+  company: Company,
+  durationMs: number,
+  error: string,
+): CompanyPipelineAnalysis {
+  return {
+    mode,
+    companyId: company.company_id,
+    companyName: company.company_name,
+    durationMs,
+    rawFindingCount: 0,
+    newFindingCount: 0,
+    finalFindingCount: 0,
+    digestFindingCount: 0,
+    highFreshCount: 0,
+    canaryCaptured: false,
+    findings: [],
+    digestFindings: [],
+    error,
+  };
+}
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  npx tsx scripts/benchmark-pipeline-real-world.ts [options]",
+    "",
+    "Options:",
+    "  --company-id <uuid>           Benchmark explicit companies only (repeatable)",
+    "  --fresh-target <n>            Fresh/new companies to include (default: 3)",
+    "  --quiet-target <n>            Quiet/low-signal companies to include (default: 2)",
+    "  --preflight-fresh-pool <n>    Fresh-history companies to preflight (default: 4)",
+    "  --preflight-quiet-pool <n>    Quiet-history companies to preflight (default: 4)",
+    "  --history-days <n>            Signal history lookback window (default: 45)",
+    "  --concurrency <n>             Companies in parallel per mode (default: 2)",
+    "  --definition-mode <mode>      deterministic or all (default: deterministic)",
+    "  --max-company-ms <n>          Hard timeout per company/mode (default: 180000)",
+    "  --output <path>               Custom markdown output path",
+    "  --help                        Show this help text",
+  ].join("\n");
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    companyIds: [],
+    freshTarget: 3,
+    quietTarget: 2,
+    preflightFreshPool: 4,
+    preflightQuietPool: 4,
+    historyDays: 45,
+    concurrency: 2,
+    definitionMode: "deterministic",
+    maxCompanyMs: 180_000,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--company-id":
+        args.companyIds.push(argv[++i] ?? "");
+        break;
+      case "--fresh-target":
+        args.freshTarget = Number(argv[++i] ?? "");
+        break;
+      case "--quiet-target":
+        args.quietTarget = Number(argv[++i] ?? "");
+        break;
+      case "--preflight-fresh-pool":
+        args.preflightFreshPool = Number(argv[++i] ?? "");
+        break;
+      case "--preflight-quiet-pool":
+        args.preflightQuietPool = Number(argv[++i] ?? "");
+        break;
+      case "--history-days":
+        args.historyDays = Number(argv[++i] ?? "");
+        break;
+      case "--concurrency":
+        args.concurrency = Number(argv[++i] ?? "");
+        break;
+      case "--definition-mode": {
+        const value = (argv[++i] ?? "").toLowerCase();
+        if (value !== "deterministic" && value !== "all") {
+          throw new Error("--definition-mode must be deterministic or all.");
+        }
+        args.definitionMode = value;
+        break;
+      }
+      case "--max-company-ms":
+        args.maxCompanyMs = Number(argv[++i] ?? "");
+        break;
+      case "--output":
+        args.outputPath = argv[++i] ?? "";
+        break;
+      case "--help":
+        console.log(usage());
+        process.exit(0);
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+  }
+
+  if (!Number.isFinite(args.freshTarget) || args.freshTarget < 0) {
+    throw new Error("--fresh-target must be a non-negative integer.");
+  }
+  if (!Number.isFinite(args.quietTarget) || args.quietTarget < 0) {
+    throw new Error("--quiet-target must be a non-negative integer.");
+  }
+  if (!Number.isFinite(args.preflightFreshPool) || args.preflightFreshPool < 1) {
+    throw new Error("--preflight-fresh-pool must be a positive integer.");
+  }
+  if (!Number.isFinite(args.preflightQuietPool) || args.preflightQuietPool < 1) {
+    throw new Error("--preflight-quiet-pool must be a positive integer.");
+  }
+  if (!Number.isFinite(args.historyDays) || args.historyDays < 1) {
+    throw new Error("--history-days must be a positive integer.");
+  }
+  if (!Number.isFinite(args.concurrency) || args.concurrency < 1) {
+    throw new Error("--concurrency must be a positive integer.");
+  }
+  if (!Number.isFinite(args.maxCompanyMs) || args.maxCompanyMs < 1_000) {
+    throw new Error("--max-company-ms must be at least 1000.");
+  }
+
+  args.freshTarget = Math.floor(args.freshTarget);
+  args.quietTarget = Math.floor(args.quietTarget);
+  args.preflightFreshPool = Math.floor(args.preflightFreshPool);
+  args.preflightQuietPool = Math.floor(args.preflightQuietPool);
+  args.historyDays = Math.floor(args.historyDays);
+  args.concurrency = Math.floor(args.concurrency);
+  args.maxCompanyMs = Math.floor(args.maxCompanyMs);
+
+  return args;
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 60_000) return `${(ms / 60_000).toFixed(2)}m`;
+  if (ms >= 1_000) return `${(ms / 1_000).toFixed(2)}s`;
+  return `${ms}ms`;
+}
+
+function compareIsoDesc(a: string | null, b: string | null): number {
+  if (a && b) return b.localeCompare(a);
+  if (a) return -1;
+  if (b) return 1;
+  return 0;
+}
+
+function dedupeByCompanyId<T extends { company: Company }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.company.company_id)) continue;
+    seen.add(item.company.company_id);
+    result.push(item);
+  }
+  return result;
+}
+
+const SEARCH_ENGINE_HOSTS = new Set([
+  "google.com",
+  "www.google.com",
+  "news.google.com",
+  "techcrunch.com",
+  "www.techcrunch.com",
+  "github.com",
+  "www.github.com",
+  "trends.google.com",
+]);
+
+function isSearchBasedDefinition(targetUrl: string): boolean {
+  try {
+    const host = new URL(targetUrl).hostname;
+    return SEARCH_ENGINE_HOSTS.has(host);
+  } catch {
+    return false;
+  }
+}
+
+async function withTimeout<T>(
+  label: string,
+  ms: number,
+  work: () => Promise<T>,
+): Promise<T> {
+  return Promise.race([
+    work(),
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    }),
+  ]);
+}
+
+function findingPreview(result: CompanyPipelineAnalysis, limit = 2): string {
+  if (result.error) return result.error;
+  if (result.findings.length === 0) return "none";
+  return result.findings
+    .slice(0, limit)
+    .map((finding) => {
+      const tier = finding.priority_tier ?? "n/a";
+      const freshness = finding.freshness_class ?? "n/a";
+      return `${finding.title} (${tier}, ${freshness})`;
+    })
+    .join(" ; ")
+    .replace(/\|/g, "/");
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) return;
+      results[currentIndex] = await worker(items[currentIndex], currentIndex);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
+}
+
+async function loadHistory(
+  companyIds: string[],
+  historyDays: number,
+): Promise<Map<string, CompanyHistorySummary>> {
+  const supabase = createAdminClient();
+  const sinceIso = new Date(
+    Date.now() - historyDays * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { data, error } = await supabase
+    .from("signals")
+    .select("company_id, detected_at, created_at, priority_tier")
+    .in("company_id", companyIds)
+    .gte("created_at", sinceIso)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load signal history: ${error.message}`);
+  }
+
+  const map = new Map<string, CompanyHistorySummary>();
+  for (const companyId of companyIds) {
+    map.set(companyId, {
+      recentSignalCount: 0,
+      recentDigestCount: 0,
+      recentFreshHighCount: 0,
+      recentLowOrStaleCount: 0,
+      latestSignalAt: null,
+    });
+  }
+
+  for (const row of (data ?? []) as HistoryRow[]) {
+    const summary = map.get(row.company_id);
+    if (!summary) continue;
+
+    const freshness = classifyFreshness(row.detected_at ?? undefined, row.created_at);
+    summary.recentSignalCount += 1;
+    if (row.priority_tier !== "low" && freshness !== "stale") {
+      summary.recentDigestCount += 1;
+    }
+    if (row.priority_tier === "high" && freshness === "fresh") {
+      summary.recentFreshHighCount += 1;
+    }
+    if (row.priority_tier === "low" || freshness === "stale") {
+      summary.recentLowOrStaleCount += 1;
+    }
+    if (!summary.latestSignalAt || row.created_at > summary.latestSignalAt) {
+      summary.latestSignalAt = row.created_at;
+    }
+  }
+
+  return map;
+}
+
+async function loadCandidates(args: Args): Promise<BenchmarkCandidate[]> {
+  const companies =
+    args.companyIds.length > 0
+      ? await getCompaniesByIds([...new Set(args.companyIds.filter(Boolean))])
+      : await getTrackedActiveCompanies();
+
+  if (companies.length === 0) {
+    throw new Error("No companies matched the requested scope.");
+  }
+
+  const historyByCompanyId = await loadHistory(
+    companies.map((company) => company.company_id),
+    args.historyDays,
+  );
+
+  const withDefinitions = await Promise.all(
+    companies.map(async (company) => {
+      const definitions = (await getSignalDefinitions(company.company_id)).filter((definition) => {
+        if (!definition.enabled) return false;
+        if (args.definitionMode === "all") return true;
+        return !isSearchBasedDefinition(resolveTemplate(definition.target_url, company));
+      });
+      return {
+        company,
+        definitions,
+        history:
+          historyByCompanyId.get(company.company_id) ?? {
+            recentSignalCount: 0,
+            recentDigestCount: 0,
+            recentFreshHighCount: 0,
+            recentLowOrStaleCount: 0,
+            latestSignalAt: null,
+          },
+      };
+    }),
+  );
+
+  return withDefinitions.filter((candidate) => candidate.definitions.length > 0);
+}
+
+function pickPreflightCandidates(
+  candidates: BenchmarkCandidate[],
+  args: Args,
+): BenchmarkCandidate[] {
+  if (args.companyIds.length > 0) {
+    return candidates;
+  }
+
+  const freshPool = [...candidates]
+    .sort((a, b) => {
+      return (
+        b.history.recentFreshHighCount - a.history.recentFreshHighCount ||
+        b.history.recentDigestCount - a.history.recentDigestCount ||
+        compareIsoDesc(a.history.latestSignalAt, b.history.latestSignalAt)
+      );
+    })
+    .slice(0, args.preflightFreshPool);
+
+  const quietPool = [...candidates]
+    .sort((a, b) => {
+      return (
+        b.history.recentLowOrStaleCount - a.history.recentLowOrStaleCount ||
+        a.history.recentFreshHighCount - b.history.recentFreshHighCount ||
+        a.history.recentDigestCount - b.history.recentDigestCount ||
+        compareIsoDesc(a.history.latestSignalAt, b.history.latestSignalAt)
+      );
+    })
+    .slice(0, args.preflightQuietPool);
+
+  return dedupeByCompanyId([...freshPool, ...quietPool]);
+}
+
+function selectCompanies(
+  preflightResults: Array<SelectedCompany>,
+  args: Args,
+): SelectedCompany[] {
+  const selected: SelectedCompany[] = [];
+
+  const fresh = preflightResults
+    .filter(
+      (candidate) =>
+        !candidate.fetchPreflight.error &&
+        candidate.fetchPreflight.finalFindingCount > 0,
+    )
+    .sort((a, b) => {
+      return (
+        b.fetchPreflight.highFreshCount - a.fetchPreflight.highFreshCount ||
+        b.fetchPreflight.digestFindingCount - a.fetchPreflight.digestFindingCount ||
+        b.fetchPreflight.finalFindingCount - a.fetchPreflight.finalFindingCount ||
+        a.fetchPreflight.durationMs - b.fetchPreflight.durationMs
+      );
+    });
+
+  for (const candidate of fresh) {
+    if (selected.length >= args.freshTarget) break;
+    selected.push({ ...candidate, selectionBucket: "fresh" });
+  }
+
+  const quiet = preflightResults
+    .filter(
+      (candidate) =>
+        !candidate.fetchPreflight.error &&
+        candidate.fetchPreflight.digestFindingCount === 0,
+    )
+    .sort((a, b) => {
+      return (
+        a.fetchPreflight.finalFindingCount - b.fetchPreflight.finalFindingCount ||
+        a.fetchPreflight.highFreshCount - b.fetchPreflight.highFreshCount ||
+        b.history.recentLowOrStaleCount - a.history.recentLowOrStaleCount
+      );
+    });
+
+  for (const candidate of quiet) {
+    if (
+      selected.filter((item) => item.selectionBucket === "quiet").length >=
+      args.quietTarget
+    ) {
+      break;
+    }
+    if (selected.some((item) => item.company.company_id === candidate.company.company_id)) {
+      continue;
+    }
+    selected.push({ ...candidate, selectionBucket: "quiet" });
+  }
+
+  const totalTarget = args.freshTarget + args.quietTarget;
+  if (selected.length < totalTarget) {
+    const fill = [...preflightResults].sort((a, b) => {
+      return (
+        b.fetchPreflight.finalFindingCount - a.fetchPreflight.finalFindingCount ||
+        b.fetchPreflight.digestFindingCount - a.fetchPreflight.digestFindingCount ||
+        a.fetchPreflight.durationMs - b.fetchPreflight.durationMs
+      );
+    });
+
+    for (const candidate of fill) {
+      if (selected.length >= totalTarget) break;
+      if (selected.some((item) => item.company.company_id === candidate.company.company_id)) {
+        continue;
+      }
+      selected.push({ ...candidate, selectionBucket: "fill" });
+    }
+  }
+
+  return selected;
+}
+
+function buildMarkdownReport(input: {
+  args: Args;
+  preflightCandidates: BenchmarkCandidate[];
+  selectedCompanies: SelectedCompany[];
+  finalResults: CompanyPipelineAnalysis[];
+}): string {
+  const { args, preflightCandidates, selectedCompanies, finalResults } = input;
+  const modeOrder: Array<CompanyPipelineAnalysis["mode"]> = [
+    "search_fetch_extract",
+    "legacy_tinyfish_agents",
+  ];
+
+  const lines: string[] = [
+    "# Real-World Pipeline Benchmark",
+    "",
+    `Run at: ${new Date().toISOString()}`,
+    `History lookback: ${args.historyDays} days`,
+    `Definition mode: ${args.definitionMode}`,
+    `Per-company timeout: ${formatMs(args.maxCompanyMs)}`,
+    `Preflight candidates: ${preflightCandidates.length}`,
+    `Selected companies: ${selectedCompanies.length}`,
+    "",
+    "## Selected Set",
+    "",
+    "| Company | Bucket | Enabled Definitions | Recent Fresh High | Recent Digest | Recent Low/Stale | Fetch New | Fetch Digest | Fetch Canary |",
+    "|---------|--------|---------------------|-------------------|---------------|------------------|-----------|--------------|--------------|",
+  ];
+
+  for (const selected of selectedCompanies) {
+    lines.push(
+      `| ${selected.company.company_name} | ${selected.selectionBucket} | ${selected.definitions.length} | ${selected.history.recentFreshHighCount} | ${selected.history.recentDigestCount} | ${selected.history.recentLowOrStaleCount} | ${selected.fetchPreflight.finalFindingCount} | ${selected.fetchPreflight.digestFindingCount} | ${selected.fetchPreflight.canaryCaptured ? "YES" : "NO"} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Mode Summary",
+    "",
+    "| Mode | Companies | Total Runtime | Avg Runtime | New Findings | Digest Findings | Canary Companies | Failures |",
+    "|------|-----------|---------------|-------------|--------------|-----------------|------------------|----------|",
+  );
+
+  for (const mode of modeOrder) {
+    const modeResults = finalResults.filter((result) => result.mode === mode);
+    const totalRuntime = modeResults.reduce(
+      (sum, result) => sum + result.durationMs,
+      0,
+    );
+    const totalNew = modeResults.reduce(
+      (sum, result) => sum + result.finalFindingCount,
+      0,
+    );
+    const totalDigest = modeResults.reduce(
+      (sum, result) => sum + result.digestFindingCount,
+      0,
+    );
+    const canaries = modeResults.filter((result) => result.canaryCaptured).length;
+    const failures = modeResults.filter((result) => !!result.error).length;
+    const avgRuntime =
+      modeResults.length > 0 ? formatMs(totalRuntime / modeResults.length) : "0ms";
+
+    lines.push(
+      `| ${mode} | ${modeResults.length} | ${formatMs(totalRuntime)} | ${avgRuntime} | ${totalNew} | ${totalDigest} | ${canaries}/${modeResults.length} | ${failures} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Per Company",
+    "",
+    "| Company | Mode | Runtime | Raw | New | Digest | Canary | Notes |",
+    "|---------|------|---------|-----|-----|--------|--------|-------|",
+  );
+
+  for (const result of finalResults) {
+    lines.push(
+      `| ${result.companyName} | ${result.mode} | ${formatMs(result.durationMs)} | ${result.rawFindingCount} | ${result.finalFindingCount} | ${result.digestFindingCount} | ${result.canaryCaptured ? "PASS" : "FAIL"} | ${findingPreview(result)} |`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const candidates = await loadCandidates(args);
+  if (candidates.length === 0) {
+    throw new Error("No benchmark candidates had enabled signal definitions.");
+  }
+
+  const preflightCandidates = pickPreflightCandidates(candidates, args);
+  console.log(
+    "[REAL-BENCH] Preflighting %d candidate companies with search_fetch_extract",
+    preflightCandidates.length,
+  );
+
+  const preflightResults = await mapWithConcurrency(
+    preflightCandidates,
+    args.concurrency,
+    async (candidate) => {
+      const analysis = await withTimeout(
+        `${candidate.company.company_name}/search_fetch_extract`,
+        args.maxCompanyMs,
+        () =>
+          analyzeCompanyWithMode(
+            "search_fetch_extract",
+            candidate.company,
+            candidate.definitions,
+          ),
+      ).catch((error) =>
+        timeoutAnalysis(
+          "search_fetch_extract",
+          candidate.company,
+          args.maxCompanyMs,
+          error instanceof Error ? error.message : String(error),
+        ),
+      );
+      return {
+        company: candidate.company,
+        definitions: candidate.definitions,
+        history: candidate.history,
+        fetchPreflight: analysis,
+        selectionBucket: "fill" as const,
+      };
+    },
+  );
+
+  const selectedCompanies = selectCompanies(preflightResults, args);
+  if (selectedCompanies.length === 0) {
+    throw new Error("Preflight did not produce any benchmarkable companies.");
+  }
+
+  console.log(
+    "[REAL-BENCH] Selected %d companies for final benchmark",
+    selectedCompanies.length,
+  );
+
+  const legacyResults = await mapWithConcurrency(
+    selectedCompanies,
+    args.concurrency,
+    async (selected) =>
+      withTimeout(
+        `${selected.company.company_name}/legacy_tinyfish_agents`,
+        args.maxCompanyMs,
+        () =>
+          analyzeCompanyWithMode(
+            "legacy_tinyfish_agents",
+            selected.company,
+            selected.definitions,
+          ),
+      ).catch((error) =>
+        timeoutAnalysis(
+          "legacy_tinyfish_agents",
+          selected.company,
+          args.maxCompanyMs,
+          error instanceof Error ? error.message : String(error),
+        ),
+      ),
+  );
+
+  const finalResults = [
+    ...selectedCompanies.map((selected) => selected.fetchPreflight),
+    ...legacyResults,
+  ].sort((a, b) => {
+    return (
+      a.companyName.localeCompare(b.companyName) ||
+      a.mode.localeCompare(b.mode)
+    );
+  });
+
+  const markdown = buildMarkdownReport({
+    args,
+    preflightCandidates,
+    selectedCompanies,
+    finalResults,
+  });
+
+  const outputPath =
+    args.outputPath ||
+    resolve(
+      process.cwd(),
+      ".context",
+      `pipeline-real-world-benchmark-${new Date()
+        .toISOString()
+        .replace(/[:.]/g, "-")}.md`,
+    );
+  const jsonPath = outputPath.replace(/\.md$/i, ".json");
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, markdown, "utf8");
+  await writeFile(
+    jsonPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        args,
+        preflightCandidates: preflightCandidates.map((candidate) => ({
+          companyId: candidate.company.company_id,
+          companyName: candidate.company.company_name,
+          enabledDefinitions: candidate.definitions.length,
+          history: candidate.history,
+        })),
+        selectedCompanies: selectedCompanies.map((selected) => ({
+          companyId: selected.company.company_id,
+          companyName: selected.company.company_name,
+          enabledDefinitions: selected.definitions.length,
+          history: selected.history,
+          selectionBucket: selected.selectionBucket,
+          fetchPreflight: selected.fetchPreflight,
+        })),
+        finalResults,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  console.log(markdown);
+  console.log("");
+  console.log("[REAL-BENCH] Markdown report: %s", outputPath);
+  console.log("[REAL-BENCH] JSON report: %s", jsonPath);
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/share-via-tinyfi.sh
+++ b/scripts/share-via-tinyfi.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+PORT="${1:-${PORT:-3000}}"
+REMOTE_PORT="${TINYFI_REMOTE_PORT:-80}"
+HOST="${TINYFI_HOST:-tinyfi.sh}"
+
+echo "Forwarding localhost:${PORT} to ${HOST} on remote port ${REMOTE_PORT}..."
+echo "Press Ctrl+C to stop the tunnel."
+
+exec ssh \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -o ExitOnForwardFailure=yes \
+  -R "${REMOTE_PORT}:localhost:${PORT}" \
+  "${HOST}"

--- a/src/app/api/benchmark-fixtures/high-signal/route.ts
+++ b/src/app/api/benchmark-fixtures/high-signal/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest } from "next/server";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function parsePublishedDate(value: string | null): string {
+  if (!value) return new Date().toISOString().slice(0, 10);
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime())
+    ? new Date().toISOString().slice(0, 10)
+    : parsed.toISOString().slice(0, 10);
+}
+
+export async function GET(request: NextRequest) {
+  const company = request.nextUrl.searchParams.get("company")?.trim() || "Stripe";
+  const token = request.nextUrl.searchParams.get("token")?.trim() || "BENCH-DEMO";
+  const source = request.nextUrl.searchParams.get("source")?.trim() || "TechCrunch";
+  const amount = request.nextUrl.searchParams.get("amount")?.trim() || "$250 million";
+  const round = request.nextUrl.searchParams.get("round")?.trim() || "Series F";
+  const date = parsePublishedDate(request.nextUrl.searchParams.get("date"));
+  const investors =
+    request.nextUrl.searchParams.get("investors")?.trim() ||
+    "Sequoia Capital, Thrive Capital, and existing backers";
+  const useOfFunds =
+    request.nextUrl.searchParams.get("useOfFunds")?.trim() ||
+    "expand enterprise payments, global treasury products, and AI-driven fraud prevention";
+
+  const headline = `${company} raises ${amount} ${round} to accelerate enterprise payments [${token}]`;
+  const pageUrl = request.nextUrl.toString();
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(headline)}</title>
+    <meta name="description" content="${escapeHtml(
+      `${company} has raised ${amount} in a ${round} round according to ${source}.`,
+    )}" />
+  </head>
+  <body style="font-family: Georgia, serif; margin: 40px auto; max-width: 760px; line-height: 1.6; color: #111;">
+    <article>
+      <header>
+        <p style="font-family: monospace; font-size: 12px; color: #666;">Benchmark fixture token: ${escapeHtml(token)}</p>
+        <h1>${escapeHtml(headline)}</h1>
+        <p><strong>Publication:</strong> ${escapeHtml(source)}</p>
+        <p><strong>Published:</strong> <time datetime="${escapeHtml(date)}">${escapeHtml(date)}</time></p>
+        <p><strong>Canonical URL:</strong> ${escapeHtml(pageUrl)}</p>
+      </header>
+
+      <p>
+        ${escapeHtml(company)} announced that it has raised ${escapeHtml(amount)} in a
+        ${escapeHtml(round)} round to ${escapeHtml(useOfFunds)}.
+        The round was led by ${escapeHtml(investors)}.
+      </p>
+
+      <p>
+        Executives said the new capital will be used to grow the company’s enterprise
+        sales team, deepen banking partnerships, and launch new infrastructure for
+        large multinational customers. The company said the financing marks one of its
+        most important capital events in the past 24 months.
+      </p>
+
+      <p>
+        This page is a controlled benchmark fixture for Daily Delta. The unique
+        benchmark token <strong>${escapeHtml(token)}</strong> should appear in the
+        extracted signal title exactly as written, and the output should keep this page
+        URL as the signal URL.
+      </p>
+    </article>
+  </body>
+</html>`;
+
+  return new Response(html, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store, max-age=0",
+    },
+  });
+}

--- a/src/services/pipeline-service.ts
+++ b/src/services/pipeline-service.ts
@@ -333,10 +333,10 @@ export async function processCompany(
       enabledDefinitions.length,
     );
 
-    // 2. Run intelligence agents
-    console.log("%s Running intelligence agents...", tag);
-    const findings = await runIntelligenceAgentsSilent(company, enabledDefinitions);
-    console.log("%s Agents returned %d findings", tag, findings.length);
+    // 2. Run the canonical production pipeline
+    console.log("%s Running default pipeline (search+fetch+extract)...", tag);
+    const findings = await collectFindingsViaDefaultPipeline(company, definitions);
+    console.log("%s Pipeline returned %d findings", tag, findings.length);
 
     // 3. Deduplicate against existing signals (fast filters: title+date, URL)
     const newFindings = await deduplicateFindings(company.company_id, findings);
@@ -903,6 +903,188 @@ async function extractSignalsFromContent(
   }
 }
 
+// Canonical production pipeline. Keep benchmark-only legacy helpers separate.
+async function collectFindingsViaDefaultPipeline(
+  company: Company,
+  definitions: SignalDefinition[],
+): Promise<SignalFinding[]> {
+  return collectFindingsViaSearchFetchExtract(company, definitions);
+}
+
+async function collectFindingsViaSearchFetchExtract(
+  company: Company,
+  definitions: SignalDefinition[],
+): Promise<SignalFinding[]> {
+  const enabledDefinitions = definitions.filter((d) => d.enabled);
+  const tag = `[PIPELINE] [${company.company_name}]`;
+
+  console.log(
+    "%s Processing %d definitions via search+fetch+extract",
+    tag,
+    enabledDefinitions.length,
+  );
+
+  const settledResults = await Promise.allSettled(
+    enabledDefinitions.map(async (definition): Promise<SignalFinding[]> => {
+      const resolvedUrl = resolveTemplate(definition.target_url, company);
+
+      if (isSearchBasedDefinition(resolvedUrl)) {
+        const query = buildSearchQuery(company, definition);
+        let searchUrls: string[] = [];
+
+        try {
+          const searchResult = await tinyfishSearch(query);
+          searchUrls = searchResult.results.slice(0, 5).map((r) => r.url);
+          console.log(
+            "%s [%s] Search API found %d results",
+            tag,
+            definition.name,
+            searchUrls.length,
+          );
+        } catch (err) {
+          console.log(
+            "%s [%s] Search API unavailable (%s), using agent to search: %s",
+            tag,
+            definition.name,
+            err instanceof Error ? err.message : String(err),
+            query,
+          );
+          searchUrls = await agentSearchForUrls(query);
+          console.log(
+            "%s [%s] Agent search found %d results",
+            tag,
+            definition.name,
+            searchUrls.length,
+          );
+        }
+
+        const pages = await Promise.all(searchUrls.map(rawFetchPage));
+        const successPages = pages.filter((p) => !p.error && p.text.length > 50);
+
+        return extractSignalsFromContent(company.company_name, definition, successPages);
+      }
+
+      console.log("%s [%s] Fetching %s", tag, definition.name, resolvedUrl);
+      const page = await rawFetchPage(resolvedUrl);
+
+      if (page.error || page.text.length < 50) {
+        console.warn(
+          "%s [%s] Fetch failed: %s",
+          tag,
+          definition.name,
+          page.error ?? "empty content",
+        );
+        return [];
+      }
+
+      return extractSignalsFromContent(company.company_name, definition, [page]);
+    }),
+  );
+
+  const findings = settledResults
+    .filter(
+      (r): r is PromiseFulfilledResult<SignalFinding[]> =>
+        r.status === "fulfilled",
+    )
+    .flatMap((r) => r.value);
+
+  const failedDefinitions = settledResults.filter((r) => r.status === "rejected");
+  if (failedDefinitions.length > 0) {
+    console.warn(
+      "%s %d/%d definitions failed during processing",
+      tag,
+      failedDefinitions.length,
+      enabledDefinitions.length,
+    );
+  }
+  console.log("%s Extracted %d total findings", tag, findings.length);
+
+  return findings;
+}
+
+export async function benchmarkCompanyWithLegacyAgents(
+  company: Company,
+  definitions: SignalDefinition[],
+  trigger: "manual" | "cron" = "manual",
+): Promise<CompanyPipelineResult> {
+  const tag = `[BENCH] [LEGACY] [${company.company_name}]`;
+  const startTime = Date.now();
+
+  try {
+    const enabledDefinitions = definitions.filter((d) => d.enabled);
+    console.log(
+      "%s Running %d TinyFish-agent definitions",
+      tag,
+      enabledDefinitions.length,
+    );
+
+    const findings = await runIntelligenceAgentsSilent(company, enabledDefinitions);
+    console.log("%s Agents returned %d findings", tag, findings.length);
+
+    const result = await persistCompanyFindings(company, definitions, trigger, findings);
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(
+      "%s Done in %ss — %d digest signals",
+      tag,
+      elapsed,
+      result.signalCount,
+    );
+    return result;
+  } catch (error) {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.error(
+      "%s FAILED after %ss: %s",
+      tag,
+      elapsed,
+      error instanceof Error ? error.message : String(error),
+    );
+    return {
+      companyId: company.company_id,
+      companyName: company.company_name,
+      signalCount: 0,
+      error: error instanceof Error ? error.message : String(error),
+      findings: [],
+    };
+  }
+}
+
+export async function benchmarkCompanyWithSearchFetchExtract(
+  company: Company,
+  definitions: SignalDefinition[],
+  trigger: "manual" | "cron" = "manual",
+): Promise<CompanyPipelineResult> {
+  const tag = `[BENCH] [FETCH] [${company.company_name}]`;
+  const startTime = Date.now();
+
+  try {
+    const findings = await collectFindingsViaSearchFetchExtract(company, definitions);
+    const result = await persistCompanyFindings(company, definitions, trigger, findings);
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(
+      "%s Done in %ss — %d digest signals",
+      tag,
+      elapsed,
+      result.signalCount,
+    );
+    return result;
+  } catch (error) {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.error(
+      "%s FAILED after %ss: %s",
+      tag,
+      elapsed,
+      error instanceof Error ? error.message : String(error),
+    );
+    return {
+      companyId: company.company_id,
+      companyName: company.company_name,
+      signalCount: 0,
+      error: error instanceof Error ? error.message : String(error),
+      findings: [],
+    };
+  }
+}
+
 export async function processCompanySignals(
   companyRunId: string,
 ): Promise<FinalizedCompanyRun> {
@@ -931,98 +1113,7 @@ export async function processCompanySignals(
   }
 
   const definitions = await getSignalDefinitions(company.company_id);
-  const enabledDefinitions = definitions.filter((d) => d.enabled);
-  const tag = `[PIPELINE] [${company.company_name}]`;
-
-  console.log(
-    "%s Processing %d definitions via search+fetch+extract",
-    tag,
-    enabledDefinitions.length,
-  );
-
-  // Process each definition in parallel — use allSettled so one failure
-  // doesn't discard results from other definitions
-  const settledResults = await Promise.allSettled(
-    enabledDefinitions.map(async (definition): Promise<SignalFinding[]> => {
-      const resolvedUrl = resolveTemplate(definition.target_url, company);
-
-      if (isSearchBasedDefinition(resolvedUrl)) {
-        // Search-based: find URLs via search, then raw fetch + LLM extract
-        const query = buildSearchQuery(company, definition);
-        let searchUrls: string[] = [];
-
-        // Try TinyFish Search API first (fastest when available)
-        try {
-          const searchResult = await tinyfishSearch(query);
-          searchUrls = searchResult.results.slice(0, 5).map((r) => r.url);
-          console.log(
-            "%s [%s] Search API found %d results",
-            tag,
-            definition.name,
-            searchUrls.length,
-          );
-        } catch (err) {
-          // Search API not available — use agent to Google search
-          console.log(
-            "%s [%s] Search API unavailable (%s), using agent to search: %s",
-            tag,
-            definition.name,
-            err instanceof Error ? err.message : String(err),
-            query,
-          );
-          searchUrls = await agentSearchForUrls(query);
-          console.log(
-            "%s [%s] Agent search found %d results",
-            tag,
-            definition.name,
-            searchUrls.length,
-          );
-        }
-
-        // Fetch all search result pages
-        const pages = await Promise.all(searchUrls.map(rawFetchPage));
-        const successPages = pages.filter((p) => !p.error && p.text.length > 50);
-
-        return extractSignalsFromContent(company.company_name, definition, successPages);
-      }
-
-      // Deterministic: directly fetch the company page
-      console.log("%s [%s] Fetching %s", tag, definition.name, resolvedUrl);
-      const page = await rawFetchPage(resolvedUrl);
-
-      if (page.error || page.text.length < 50) {
-        console.warn(
-          "%s [%s] Fetch failed: %s",
-          tag,
-          definition.name,
-          page.error ?? "empty content",
-        );
-        return [];
-      }
-
-      return extractSignalsFromContent(company.company_name, definition, [page]);
-    }),
-  );
-
-  const findings = settledResults
-    .filter(
-      (r): r is PromiseFulfilledResult<SignalFinding[]> =>
-        r.status === "fulfilled",
-    )
-    .flatMap((r) => r.value);
-
-  const failedDefinitions = settledResults.filter(
-    (r) => r.status === "rejected",
-  );
-  if (failedDefinitions.length > 0) {
-    console.warn(
-      "%s %d/%d definitions failed during processing",
-      tag,
-      failedDefinitions.length,
-      enabledDefinitions.length,
-    );
-  }
-  console.log("%s Extracted %d total findings", tag, findings.length);
+  const findings = await collectFindingsViaDefaultPipeline(company, definitions);
 
   // Feed into existing dedup + score + report pipeline
   const result = await persistCompanyFindings(
@@ -1113,6 +1204,100 @@ export async function maybeReuseRecentReport(
       reportId: recent.report.report_id,
     },
   };
+}
+
+export type PipelineBenchmarkMode =
+  | "legacy_tinyfish_agents"
+  | "search_fetch_extract";
+
+export interface CompanyPipelineAnalysis {
+  mode: PipelineBenchmarkMode;
+  companyId: string;
+  companyName: string;
+  durationMs: number;
+  rawFindingCount: number;
+  newFindingCount: number;
+  finalFindingCount: number;
+  digestFindingCount: number;
+  highFreshCount: number;
+  canaryCaptured: boolean;
+  findings: SignalFinding[];
+  digestFindings: SignalFinding[];
+  error?: string;
+}
+
+async function collectFindingsForMode(
+  mode: PipelineBenchmarkMode,
+  company: Company,
+  definitions: SignalDefinition[],
+): Promise<SignalFinding[]> {
+  if (mode === "legacy_tinyfish_agents") {
+    const enabledDefinitions = definitions.filter((definition) => definition.enabled);
+    return runIntelligenceAgentsSilent(company, enabledDefinitions);
+  }
+
+  return collectFindingsViaSearchFetchExtract(company, definitions);
+}
+
+export async function analyzeCompanyWithMode(
+  mode: PipelineBenchmarkMode,
+  company: Company,
+  definitions: SignalDefinition[],
+): Promise<CompanyPipelineAnalysis> {
+  const startedAt = Date.now();
+
+  try {
+    const rawFindings = await collectFindingsForMode(mode, company, definitions);
+    const newFindings = await deduplicateFindings(company.company_id, rawFindings);
+    const finalFindings = await llmDedup(company.company_id, newFindings);
+
+    for (const finding of finalFindings) {
+      const { score, tier } = scoreSignalFinding(finding);
+      finding.priority_score = score;
+      finding.priority_tier = tier;
+      finding.freshness_class = classifyFreshness(finding.detected_at);
+    }
+
+    const digestFindings = finalFindings.filter(
+      (finding) =>
+        finding.priority_tier !== "low" && finding.freshness_class !== "stale",
+    );
+    const highFreshCount = digestFindings.filter(
+      (finding) =>
+        finding.priority_tier === "high" && finding.freshness_class === "fresh",
+    ).length;
+
+    return {
+      mode,
+      companyId: company.company_id,
+      companyName: company.company_name,
+      durationMs: Date.now() - startedAt,
+      rawFindingCount: rawFindings.length,
+      newFindingCount: newFindings.length,
+      finalFindingCount: finalFindings.length,
+      digestFindingCount: digestFindings.length,
+      highFreshCount,
+      canaryCaptured: highFreshCount > 0,
+      findings: finalFindings,
+      digestFindings,
+    };
+  } catch (error) {
+    return {
+      mode,
+      companyId: company.company_id,
+      companyName: company.company_name,
+      durationMs: Date.now() - startedAt,
+      rawFindingCount: 0,
+      newFindingCount: 0,
+      finalFindingCount: 0,
+      digestFindingCount: 0,
+      highFreshCount: 0,
+      canaryCaptured: false,
+      findings: [],
+      digestFindings: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 async function persistCompanyFindings(

--- a/supabase/migrations/20260405180500_add_signal_priority_columns.sql
+++ b/supabase/migrations/20260405180500_add_signal_priority_columns.sql
@@ -1,0 +1,7 @@
+-- Add scoring columns for pipeline signal prioritization
+ALTER TABLE public.signals
+ADD COLUMN IF NOT EXISTS priority_score integer;
+
+ALTER TABLE public.signals
+ADD COLUMN IF NOT EXISTS priority_tier text
+CHECK (priority_tier IN ('high', 'medium', 'low'));


### PR DESCRIPTION
## Summary
- make the search/fetch pipeline the default production path
- add tinyfi-backed benchmark tooling and a real-world benchmark harness
- add the benchmark fixture route and priority column migration

## Verification
- npx tsc --noEmit
- ran deterministic real-world benchmark and wrote reports under .context/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Signals now feature priority scoring and automatic tier classification with configurable levels (high, medium, low) for improved organization and ranking

* **Improvements**
  * Enhanced core extraction pipeline with upgraded methodology for more accurate signal discovery

* **Developer Tools**
  * New benchmarking commands and SSH-based remote sharing utility for developers and testers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->